### PR TITLE
Add API services and integrate login

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
+// BaseURL apuntando directamente a la API desplegada
 const api = axios.create({
-  baseURL: '/api',  // En Vercel las serverless están bajo /api
+  baseURL: 'https://warapi.onrender.com'
 });
 
 export default api;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,0 +1,4 @@
+import api from './api';
+
+export const login = (credentials) => api.post('/Player/login', credentials);
+

--- a/frontend/src/services/playerService.js
+++ b/frontend/src/services/playerService.js
@@ -1,0 +1,6 @@
+import api from './api';
+
+export const getAllPlayers = () => api.get('/Player');
+export const createPlayer = (player) => api.post('/Player', player);
+export const deletePlayer = (id) => api.delete(`/Player/${id}`);
+

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -1,0 +1,5 @@
+import api from './api';
+
+export const getAllReports = () => api.get('/MatchReport');
+export const createReport = (report) => api.post('/MatchReport', report);
+

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -31,6 +31,8 @@
 </template>
 
 <script>
+import { login } from '@/services/authService';
+
 export default {
   data() {
     return {
@@ -40,14 +42,18 @@ export default {
     };
   },
   methods: {
-    handleLogin() {
-      // Simulación de login
-      if (this.email === "admin@warhammer.com" && this.password === "123456") {
-        localStorage.setItem("token", "mock-token-123");
-        localStorage.setItem("user", JSON.stringify({ email: this.email }));
-        this.$router.push("/dashboard");
-      } else {
-        this.error = "Correo o contraseña incorrectos";
+    async handleLogin() {
+      this.error = null;
+      try {
+        const { data } = await login({
+          email: this.email,
+          contraseña: this.password,
+        });
+        localStorage.setItem('token', data.token);
+        localStorage.setItem('user', JSON.stringify(data.user));
+        this.$router.push('/dashboard');
+      } catch (err) {
+        this.error = err.response?.data?.message || 'Correo o contraseña incorrectos';
       }
     },
   },


### PR DESCRIPTION
## Summary
- add API configuration for WarAPI
- add Player, Report and Auth services
- update LoginView to authenticate with backend

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565db59a1c83219e84e51f50d95083