### PR TITLE
Connect frontend views with API

### DIFF
--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -274,6 +274,7 @@ import {
   primaries,
   secondaries,
 } from "@/mock/reportOptions.js";
+import { createReport } from '@/services/reportService';
 
 export default {
   data() {
@@ -413,7 +414,7 @@ export default {
       this.currentInfo = info;
       this.infoDialog = true;
     },
-    saveReport() {
+    async saveReport() {
       const report = {
         date: this.reportDate,
         player: this.player,
@@ -432,7 +433,12 @@ export default {
         secondaryOpponentCompleted: this.secondaryOpponentCompleted,
         finalScore: this.finalScore,
       };
-      console.log("Reporte guardado:", report);
+      try {
+        await createReport(report);
+        this.$router.push('/dashboard');
+      } catch (err) {
+        console.error('Error saving report', err);
+      }
     },
   },
 };

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -177,71 +177,12 @@
 </template>
 
 <script>
+import { getAllReports } from '@/services/reportService';
+
 export default {
   data() {
     return {
-      reports: [
-        {
-          id: 1,
-          date: "2025-06-06",
-          player: { name: "Thorin", army: "Dwarven Holds" },
-          opponent: { name: "Elrond" },
-          map: "Bosque de las Sombras",
-          deployment: "Frontline Clash",
-          primaryMission: "Spoils of War",
-          primaryResult: "player",
-          secondaryPlayer: "Capture the Flags",
-          secondaryOpponent: "Slay the Beast",
-          pointsPlayer: 3000,
-          pointsOpponent: 2500,
-          finalScore: "15-5",
-        },
-        {
-          id: 2,
-          date: "2025-06-05",
-          player: { name: "Eowyn", army: "Kingdom of Equitaine" },
-          opponent: { name: "Saruman" },
-          map: "Colinas de Sangre",
-          deployment: "Refused Flank",
-          primaryMission: "Breakthrough",
-          primaryResult: "opponent",
-          secondaryPlayer: "Stand Firm",
-          secondaryOpponent: "Forbid Trespass",
-          pointsPlayer: 1800,
-          pointsOpponent: 2200,
-          finalScore: "8-12",
-        },
-        {
-          id: 3,
-          date: "2025-06-04",
-          player: { name: "Gimli", army: "Infernal Dwarves" },
-          opponent: { name: "Boromir" },
-          map: "Campos de Pelennor",
-          deployment: "Spearhead",
-          primaryMission: "Hold the Centre",
-          primaryResult: "both",
-          secondaryPlayer: "Slay the Beast",
-          secondaryOpponent: "Demonstrate Superiority",
-          pointsPlayer: 2000,
-          pointsOpponent: 2000,
-          finalScore: "10-10",
-        },
-        {
-          id: 4,
-          date: "2025-06-03",
-          player: { name: "Faramir", army: "Highborn Elves" },
-          opponent: { name: "Gollum" },
-          map: "Ruinas de Osgiliath",
-          deployment: "Mutual Encroachment",
-          primaryMission: "Forage and Plunder",
-          primaryResult: "none",
-          secondaryPlayer: "Work as One",
-          secondaryOpponent: "Commit to Battle",
-          pointsPlayer: 2700,
-          pointsOpponent: 2100,
-          finalScore: "14-6",
-        },
-      ],
+      reports: [],
 
       visibleReports: [],
       itemsPerPage: 5,
@@ -270,9 +211,23 @@ export default {
     },
   },
   created() {
-    this.loadMoreReports();
+    this.fetchReports();
   },
   methods: {
+    async fetchReports() {
+      try {
+        this.loading = true;
+        const { data } = await getAllReports();
+        this.reports = data;
+        this.visibleReports = [];
+        this.allLoaded = false;
+      } catch (err) {
+        console.error('Error fetching reports', err);
+      } finally {
+        this.loading = false;
+        this.loadMoreReports();
+      }
+    },
     armyImage(armyName) {
       const armyMap = {
         "Highborn Elves": "Altos.png",

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -149,12 +149,12 @@
 
 <script>
 import Chart from "chart.js/auto";
-import reports from "@/mock/statisticsMock.js"; // Aquí tu mock real
+import { getAllReports } from '@/services/reportService';
 
 export default {
   data() {
     return {
-      reports,
+      reports: [],
     };
   },
   computed: {
@@ -285,9 +285,18 @@ export default {
         },
       });
     },
+    async fetchReports() {
+      try {
+        const { data } = await getAllReports();
+        this.reports = data;
+        this.setupCharts();
+      } catch (err) {
+        console.error('Error fetching reports', err);
+      }
+    },
   },
   mounted() {
-    this.setupCharts();
+    this.fetchReports();
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- load reports from backend in dashboard
- submit reports through the API
- show statistics using API data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857ab7aeed88321bd3ca4b4be57a6ee