### PR TITLE
Connect frontend views with API

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,19 +16,19 @@
 
   body {
     font-family: 'Merriweather', serif;
-    background-color: #1E1E1E;
-    color: #F5F5F5;
+    background-color: #000;
+    color: #f5f5f5;
   }
 
   a {
-    color: #C5A880;
+    color: #ffef00;
     text-decoration: none;
   }
 
   button {
-    background-color: #8B0000;
-    color: #F5F5F5;
-    border: 1px solid #C5A880;
+    background-color: #6a0dad;
+    color: #ffef00;
+    border: 1px solid #00bfff;
     padding: 10px 20px;
     font-size: 1rem;
     cursor: pointer;
@@ -37,13 +37,13 @@
   }
 
   button:hover {
-    background-color: #B22222;
+    background-color: #00bfff;
   }
 
   input, textarea {
-    background-color: #2B2B2B;
-    border: 1px solid #C5A880;
-    color: #F5F5F5;
+    background-color: #1e1e1e;
+    border: 1px solid #00bfff;
+    color: #ffef00;
     padding: 10px;
     margin: 10px 0;
     width: 100%;
@@ -54,13 +54,13 @@
     max-width: 800px;
     margin: 2rem auto;
     padding: 2rem;
-    background-color: #2B2B2B;
+    background-color: #121212;
     border-radius: 10px;
     box-shadow: 0 4px 8px rgba(0,0,0,0.5);
   }
 
   h1, h2 {
-    color: #C5A880;
+    color: #00bfff;
   }
 </style>
 

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -9,6 +9,18 @@ export default createVuetify({
     sets: { mdi },
   },
   theme: {
-    defaultTheme: 'dark',
+    defaultTheme: 'esports',
+    themes: {
+      esports: {
+        dark: true,
+        colors: {
+          background: '#000000',
+          surface: '#121212',
+          primary: '#00bfff',
+          secondary: '#6a0dad',
+          accent: '#ffef00',
+        },
+      },
+    },
   },
 })

--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -274,6 +274,7 @@ import {
   primaries,
   secondaries,
 } from "@/mock/reportOptions.js";
+import { createReport } from '@/services/reportService';
 
 export default {
   data() {
@@ -413,7 +414,7 @@ export default {
       this.currentInfo = info;
       this.infoDialog = true;
     },
-    saveReport() {
+    async saveReport() {
       const report = {
         date: this.reportDate,
         player: this.player,
@@ -432,7 +433,12 @@ export default {
         secondaryOpponentCompleted: this.secondaryOpponentCompleted,
         finalScore: this.finalScore,
       };
-      console.log("Reporte guardado:", report);
+      try {
+        await createReport(report);
+        this.$router.push('/dashboard');
+      } catch (err) {
+        console.error('Error saving report', err);
+      }
     },
   },
 };
@@ -441,5 +447,6 @@ export default {
 <style scoped>
 .v-card-title {
   font-weight: bold;
+  color: #ffef00;
 }
 </style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -177,71 +177,12 @@
 </template>
 
 <script>
+import { getAllReports } from '@/services/reportService';
+
 export default {
   data() {
     return {
-      reports: [
-        {
-          id: 1,
-          date: "2025-06-06",
-          player: { name: "Thorin", army: "Dwarven Holds" },
-          opponent: { name: "Elrond" },
-          map: "Bosque de las Sombras",
-          deployment: "Frontline Clash",
-          primaryMission: "Spoils of War",
-          primaryResult: "player",
-          secondaryPlayer: "Capture the Flags",
-          secondaryOpponent: "Slay the Beast",
-          pointsPlayer: 3000,
-          pointsOpponent: 2500,
-          finalScore: "15-5",
-        },
-        {
-          id: 2,
-          date: "2025-06-05",
-          player: { name: "Eowyn", army: "Kingdom of Equitaine" },
-          opponent: { name: "Saruman" },
-          map: "Colinas de Sangre",
-          deployment: "Refused Flank",
-          primaryMission: "Breakthrough",
-          primaryResult: "opponent",
-          secondaryPlayer: "Stand Firm",
-          secondaryOpponent: "Forbid Trespass",
-          pointsPlayer: 1800,
-          pointsOpponent: 2200,
-          finalScore: "8-12",
-        },
-        {
-          id: 3,
-          date: "2025-06-04",
-          player: { name: "Gimli", army: "Infernal Dwarves" },
-          opponent: { name: "Boromir" },
-          map: "Campos de Pelennor",
-          deployment: "Spearhead",
-          primaryMission: "Hold the Centre",
-          primaryResult: "both",
-          secondaryPlayer: "Slay the Beast",
-          secondaryOpponent: "Demonstrate Superiority",
-          pointsPlayer: 2000,
-          pointsOpponent: 2000,
-          finalScore: "10-10",
-        },
-        {
-          id: 4,
-          date: "2025-06-03",
-          player: { name: "Faramir", army: "Highborn Elves" },
-          opponent: { name: "Gollum" },
-          map: "Ruinas de Osgiliath",
-          deployment: "Mutual Encroachment",
-          primaryMission: "Forage and Plunder",
-          primaryResult: "none",
-          secondaryPlayer: "Work as One",
-          secondaryOpponent: "Commit to Battle",
-          pointsPlayer: 2700,
-          pointsOpponent: 2100,
-          finalScore: "14-6",
-        },
-      ],
+      reports: [],
 
       visibleReports: [],
       itemsPerPage: 5,
@@ -270,9 +211,23 @@ export default {
     },
   },
   created() {
-    this.loadMoreReports();
+    this.fetchReports();
   },
   methods: {
+    async fetchReports() {
+      try {
+        this.loading = true;
+        const { data } = await getAllReports();
+        this.reports = data;
+        this.visibleReports = [];
+        this.allLoaded = false;
+      } catch (err) {
+        console.error('Error fetching reports', err);
+      } finally {
+        this.loading = false;
+        this.loadMoreReports();
+      }
+    },
     armyImage(armyName) {
       const armyMap = {
         "Highborn Elves": "Altos.png",
@@ -363,28 +318,22 @@ export default {
 .card-win {
   background: linear-gradient(
     117deg,
-    rgba(50, 204, 47, 1) 0%,
-    rgba(141, 214, 139, 1) 8%,
-    rgba(110, 119, 156, 1) 52%,
-    rgba(110, 119, 156, 1) 100%
+    #00bfff 0%,
+    #6a0dad 100%
   );
 }
 .card-lose {
   background: linear-gradient(
     117deg,
-    rgba(204, 84, 47, 1) 0%,
-    rgba(214, 139, 139, 1) 8%,
-    rgba(110, 119, 156, 1) 52%,
-    rgba(110, 119, 156, 1) 100%
+    #6a0dad 0%,
+    #b00020 100%
   );
 }
 .card-draw {
   background: linear-gradient(
     117deg,
-    rgb(128, 193, 255) 0%,
-    rgb(175, 216, 255) 8%,
-    rgba(110, 119, 156, 1) 52%,
-    rgba(110, 119, 156, 1) 100%
+    #ffef00 0%,
+    #6a0dad 100%
   );
 }
 

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -149,12 +149,12 @@
 
 <script>
 import Chart from "chart.js/auto";
-import reports from "@/mock/statisticsMock.js"; // Aquí tu mock real
+import { getAllReports } from '@/services/reportService';
 
 export default {
   data() {
     return {
-      reports,
+      reports: [],
     };
   },
   computed: {
@@ -264,7 +264,7 @@ export default {
           datasets: [
             {
               data: [this.totalWins, this.totalLosses, this.totalDraws],
-              backgroundColor: ["#4CAF50", "#F44336", "#FFC107"],
+              backgroundColor: ["#00bfff", "#6a0dad", "#ffef00"],
             },
           ],
         },
@@ -279,15 +279,24 @@ export default {
             {
               label: "Veces Jugado",
               data: this.topMaps.map((m) => m[1]),
-              backgroundColor: "#42A5F5",
+              backgroundColor: "#00bfff",
             },
           ],
         },
       });
     },
+    async fetchReports() {
+      try {
+        const { data } = await getAllReports();
+        this.reports = data;
+        this.setupCharts();
+      } catch (err) {
+        console.error('Error fetching reports', err);
+      }
+    },
   },
   mounted() {
-    this.setupCharts();
+    this.fetchReports();
   },
 };
 </script>
@@ -309,9 +318,9 @@ export default {
   text-align: center;
 }
 .v-table th {
-  background-color: #42a5f5;
+  background-color: #6a0dad;
 }
 .v-table tbody tr:nth-child(even) {
-  background-color: #5b6b79;
+  background-color: #1e1e1e;
 }
 </style>


### PR DESCRIPTION
## Summary
- load reports from backend in dashboard
- submit reports through the API
- show statistics using API data
- modernize styles with an eSports color theme

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857ab7aeed88321bd3ca4b4be57a6ee