### PR TITLE
Implement player autocomplete in CreateReportView

### DIFF
--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -239,7 +239,14 @@
       <v-card>
         <v-card-title>Jugador</v-card-title>
         <v-card-text>
-          <v-text-field v-model="player.name" label="Nombre" outlined />
+          <v-autocomplete
+            v-model="player.id"
+            :items="players"
+            item-title="name"
+            item-value="id"
+            label="Nombre"
+            outlined
+          />
           <v-textarea v-model="player.list" label="Lista" rows="6" outlined />
         </v-card-text>
         <v-card-actions>
@@ -254,7 +261,14 @@
       <v-card>
         <v-card-title>Oponente</v-card-title>
         <v-card-text>
-          <v-text-field v-model="opponent.name" label="Nombre" outlined />
+          <v-autocomplete
+            v-model="opponent.id"
+            :items="players"
+            item-title="name"
+            item-value="id"
+            label="Nombre"
+            outlined
+          />
           <v-textarea v-model="opponent.list" label="Lista" rows="6" outlined />
         </v-card-text>
         <v-card-actions>
@@ -275,6 +289,7 @@ import {
   secondaries,
 } from "@/mock/reportOptions.js";
 import { createReport } from '@/services/reportService';
+import { getAllPlayers } from '@/services/playerService';
 
 export default {
   data() {
@@ -283,8 +298,9 @@ export default {
       reportDate: new Date().toISOString().substr(0, 10),
       playerDialog: false,
       opponentDialog: false,
-      player: { name: "", list: "" },
-      opponent: { name: "", list: "" },
+      player: { id: null, list: "" },
+      opponent: { id: null, list: "" },
+      players: [],
       maps,
       deployments,
       primaries,
@@ -315,16 +331,19 @@ export default {
       secondaryOpponentCompleted: false,
     };
   },
+  created() {
+    this.fetchPlayers();
+  },
   computed: {
     currentTitle() {
       const titles = ["Información General", "Turnos de Magia", "Resultados"];
       return titles[this.step - 1] || "Paso";
     },
     playerComplete() {
-      return this.player.name && this.player.list;
+      return this.player.id && this.player.list;
     },
     opponentComplete() {
-      return this.opponent.name && this.opponent.list;
+      return this.opponent.id && this.opponent.list;
     },
     magicComplete() {
       return (
@@ -398,6 +417,14 @@ export default {
     },
   },
   methods: {
+    async fetchPlayers() {
+      try {
+        const { data } = await getAllPlayers();
+        this.players = data;
+      } catch (err) {
+        console.error('Error fetching players', err);
+      }
+    },
     openPlayerDialog() {
       this.playerDialog = true;
     },
@@ -416,8 +443,8 @@ export default {
     },
     async saveReport() {
       const report = {
-        PlayerAId: this.player.name,
-        PlayerBId: this.opponent.name,
+        PlayerAId: this.player.id,
+        PlayerBId: this.opponent.id,
         listA: this.player.list,
         listB: this.opponent.list,
         expectedA,


### PR DESCRIPTION
## Summary
- use `v-autocomplete` for selecting players in report dialogs
- load players on view creation via `getAllPlayers`
- store selected player ids and send them when creating a report

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858f241eb5883218e756ee71b2653cb