### PR TITLE
Implement client services for new API endpoints

### DIFF
--- a/frontend/src/services/playerService.js
+++ b/frontend/src/services/playerService.js
@@ -4,4 +4,6 @@ export const getAllPlayers = () => api.get('/Player');
 export const createPlayer = (player) => api.post('/Player', player);
 export const deletePlayer = (id) => api.delete(`/Player/${id}`);
 export const getPlayerByEmail = (email) => api.get(`/Player/GetByEmail?email=${email}`);
+export const getPlayerById = (id) => api.get(`/Player/${id}`);
+export const updatePlayer = (id, player) => api.put(`/Player/${id}`, player);
 

--- a/frontend/src/services/playerStatsService.js
+++ b/frontend/src/services/playerStatsService.js
@@ -1,0 +1,24 @@
+import api from './api';
+
+export const getTotal = (playerId) =>
+  api.get(`/api/playerstats/${playerId}/total`);
+export const getWins = (playerId) =>
+  api.get(`/api/playerstats/${playerId}/wins`);
+export const getLosses = (playerId) =>
+  api.get(`/api/playerstats/${playerId}/losses`);
+export const getDraws = (playerId) =>
+  api.get(`/api/playerstats/${playerId}/draws`);
+export const getGamesByArmy = (playerId, army) =>
+  api.get(`/api/playerstats/${playerId}/army/${army}/total`);
+export const getWinsByArmy = (playerId, army) =>
+  api.get(`/api/playerstats/${playerId}/army/${army}/wins`);
+export const getMapWinRate = (playerId, map) =>
+  api.get(`/api/playerstats/${playerId}/map/${map}/winrate`);
+export const getDeploymentWinRate = (playerId, deployment) =>
+  api.get(`/api/playerstats/${playerId}/deployment/${deployment}/winrate`);
+export const getPrimaryWinRate = (playerId, mission) =>
+  api.get(`/api/playerstats/${playerId}/primary/${mission}/winrate`);
+export const getBestOpponent = (playerId) =>
+  api.get(`/api/playerstats/${playerId}/best-opponent`);
+export const getWorstOpponent = (playerId) =>
+  api.get(`/api/playerstats/${playerId}/worst-opponent`);

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -2,6 +2,10 @@ import api from './api';
 
 export const getAllReports = () => api.get('/api/matchreports');
 export const createReport = (report) => api.post('/api/matchreports', report);
-export const getReportsByPlayer = (id) =>
-  api.get(`/api/matchreports/${id}`);
+export const getReportById = (id) => api.get(`/api/matchreports/${id}`);
+export const getReportsByPlayer = (playerId) =>
+  api.get(`/api/matchreports/player/${playerId}`);
+export const updateReport = (id, report) =>
+  api.put(`/api/matchreports/${id}`, report);
+export const deleteReport = (id) => api.delete(`/api/matchreports/${id}`);
 

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -39,6 +39,27 @@
       </v-col>
     </v-row>
 
+    <!-- Mejores y Peores Oponentes -->
+    <v-row class="mb-6" justify="center">
+      <v-col cols="12" md="6" class="d-flex">
+        <v-card class="flex-grow-1">
+          <v-card-title class="text-center">Mejor Contra</v-card-title>
+          <v-card-text class="text-center">
+            <span class="text-h5">{{ bestOpponent || 'N/A' }}</span>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <v-col cols="12" md="6" class="d-flex">
+        <v-card class="flex-grow-1">
+          <v-card-title class="text-center">Peor Contra</v-card-title>
+          <v-card-text class="text-center">
+            <span class="text-h5">{{ worstOpponent || 'N/A' }}</span>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
     <!-- Gráficos -->
     <v-row class="mb-6">
       <v-col cols="12" md="6">
@@ -149,12 +170,15 @@
 
 <script>
 import Chart from "chart.js/auto";
-import { getAllReports } from '@/services/reportService';
+import { getReportsByPlayer } from '@/services/reportService';
+import { getBestOpponent, getWorstOpponent } from '@/services/playerStatsService';
 
 export default {
   data() {
     return {
       reports: [],
+      bestOpponent: '',
+      worstOpponent: '',
     };
   },
   computed: {
@@ -287,16 +311,34 @@ export default {
     },
     async fetchReports() {
       try {
-        const { data } = await getAllReports();
+        const sessionUser = sessionStorage.getItem('user');
+        if (!sessionUser) throw new Error('Usuario no encontrado');
+        const user = JSON.parse(sessionUser);
+        const { data } = await getReportsByPlayer(user.id);
         this.reports = data;
         this.setupCharts();
       } catch (err) {
         console.error('Error fetching reports', err);
       }
     },
+
+    async fetchStats() {
+      try {
+        const sessionUser = sessionStorage.getItem('user');
+        if (!sessionUser) throw new Error('Usuario no encontrado');
+        const user = JSON.parse(sessionUser);
+        const { data: best } = await getBestOpponent(user.id);
+        const { data: worst } = await getWorstOpponent(user.id);
+        this.bestOpponent = best;
+        this.worstOpponent = worst;
+      } catch (err) {
+        console.error('Error fetching stats', err);
+      }
+    },
   },
   mounted() {
     this.fetchReports();
+    this.fetchStats();
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- extend Player service with get-by-id and update helpers
- expand Report service to support new report endpoints
- create Player Stats service wrapping statistics endpoints
- show best/worst opponents on statistics page

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_685b9434381083219b0364884a27264f