### PR TITLE
Switch to hash-based router history

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 
 // Importaciones estáticas o lazy
 import LoginView from '@/views/LoginView.vue'
@@ -37,7 +37,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   routes
 })
 


### PR DESCRIPTION
## Summary
- update router to use `createWebHashHistory`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685bcd7012a48321a34fed9d1afd70b8