### PR TITLE
Enhance report display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Battle Reports</title>
-    <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Bebas+Neue&display=swap" rel="stylesheet">
 
 <style>
   * {
@@ -15,7 +15,7 @@
   }
 
   body {
-    font-family: 'Merriweather', serif;
+    font-family: 'Roboto', sans-serif;
     background-color: #000;
     color: #f5f5f5;
   }
@@ -61,6 +61,7 @@
 
   h1, h2 {
     color: #00bfff;
+    font-family: 'Bebas Neue', cursive;
   }
 </style>
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -35,6 +35,6 @@ export default {
 
 <style scoped>
 .v-application {
-  font-family: "Merriweather", serif;
+  font-family: "Roboto", sans-serif;
 }
 </style>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Bebas+Neue&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Roboto', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
@@ -28,6 +30,12 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+}
+
+h1, h2, h3, .v-card-title {
+  font-family: 'Bebas Neue', cursive;
+  font-weight: 400;
+  letter-spacing: 0.5px;
 }
 
 h1 {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -64,13 +64,22 @@
             </div>
           </v-card-text>
 
-          <v-avatar size="64" class="army-avatar">
-            <v-img
-              :src="armyImage(report.player?.army)"
-              alt="Army Icon"
-              contain
-            />
-          </v-avatar>
+          <div class="army-avatars">
+            <v-avatar size="48" class="mx-1">
+              <v-img
+                :src="armyImage(report.armyPlayer)"
+                alt="Army A"
+                contain
+              />
+            </v-avatar>
+            <v-avatar size="48" class="mx-1">
+              <v-img
+                :src="armyImage(report.armyOpponent)"
+                alt="Army B"
+                contain
+              />
+            </v-avatar>
+          </div>
         </v-card>
       </v-col>
     </v-row>
@@ -93,6 +102,14 @@
       <v-card>
         <v-card-title>Detalles del Reporte</v-card-title>
         <v-card-text v-if="selectedReport">
+          <div class="d-flex justify-center mb-3">
+            <v-avatar size="64" class="mx-1">
+              <v-img :src="armyImage(selectedReport.armyPlayer)" alt="Army A" contain />
+            </v-avatar>
+            <v-avatar size="64" class="mx-1">
+              <v-img :src="armyImage(selectedReport.armyOpponent)" alt="Army B" contain />
+            </v-avatar>
+          </div>
           <v-list dense>
             <v-list-item>
               <v-list-item-title>Jugador</v-list-item-title>
@@ -178,6 +195,20 @@
               }}</v-list-item-subtitle>
             </v-list-item>
           </v-list>
+          <v-expansion-panels class="mt-4">
+            <v-expansion-panel>
+              <v-expansion-panel-title>Lista Jugador</v-expansion-panel-title>
+              <v-expansion-panel-text>
+                <pre class="preformatted">{{ selectedReport.listPlayer }}</pre>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+            <v-expansion-panel>
+              <v-expansion-panel-title>Lista Oponente</v-expansion-panel-title>
+              <v-expansion-panel-text>
+                <pre class="preformatted">{{ selectedReport.listOpponent }}</pre>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+          </v-expansion-panels>
         </v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -220,7 +251,8 @@ export default {
           report.map.toLowerCase().includes(query) ||
           report.deployment.toLowerCase().includes(query) ||
           report.finalScore.includes(query) ||
-          report.player.army?.toLowerCase().includes(query) // <-- Añadido aquí
+          report.armyPlayer?.toLowerCase().includes(query) ||
+          report.armyOpponent?.toLowerCase().includes(query)
         );
       });
     },
@@ -246,6 +278,10 @@ export default {
           const isPlayerA = r.playerAId === playerId;
           const player = isPlayerA ? r.playerA : r.playerB;
           const opponent = isPlayerA ? r.playerB : r.playerA;
+          const armyPlayer = isPlayerA ? r.armyA : r.armyB;
+          const armyOpponent = isPlayerA ? r.armyB : r.armyA;
+          const listPlayer = isPlayerA ? r.listA : r.listB;
+          const listOpponent = isPlayerA ? r.listB : r.listA;
 
           let primaryResult = "none";
           if (r.primaryResult === 1) {
@@ -262,6 +298,10 @@ export default {
             deployment: r.deployment,
             primaryMission: r.primaryMission,
             date: r.date,
+            armyPlayer,
+            armyOpponent,
+            listPlayer,
+            listOpponent,
             secondaryPlayer: isPlayerA ? r.secondaryA : r.secondaryB,
             secondaryOpponent: isPlayerA ? r.secondaryB : r.secondaryA,
             pointsPlayer: isPlayerA ? r.killsA : r.killsB,
@@ -385,12 +425,23 @@ export default {
   position: relative;
 }
 
-/* Avatar en la esquina inferior derecha */
-.army-avatar {
+
+/* Container for two army avatars */
+.army-avatars {
   position: absolute;
   bottom: 8px;
   right: 8px;
-  background-color: white; /* opcional: para que destaque el avatar */
+  display: flex;
+  background-color: white;
+  padding: 2px;
+  border-radius: 8px;
+}
+
+.preformatted {
+  white-space: pre-wrap;
+  font-family: monospace;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .modern-btn {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -88,7 +88,7 @@ export default {
 </script>
 
 <style scoped>
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Bebas+Neue&display=swap");
 
 .v-container {
   background-image: url("../../public/Login_Gif2.gif");
@@ -97,7 +97,7 @@ export default {
   background-repeat: no-repeat;
   min-height: 100vh;
   position: relative;
-  font-family: "Poppins", sans-serif;
+  font-family: "Roboto", sans-serif;
 }
 
 .v-container::before {


### PR DESCRIPTION
## Summary
- use modern Roboto font for body text and Bebas Neue for headings
- show player and opponent army icons on dashboard cards and in the report modal
- include list text in expandable panels for each report

## Testing
- `npm --version`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfb8189048321afda0600b7758d29