### PR TITLE
Add user profile view with edit and deletion

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,7 @@ import LoginView from '@/views/LoginView.vue'
 import DashboardView from '@/views/DashboardView.vue'
 import CreateReportView from '@/views/CreateReportView.vue'
 import StatisticsView from '@/views/StatisticsView.vue'
+import ProfileView from '@/views/ProfileView.vue'
 
 const routes = [
   {
@@ -28,6 +29,12 @@ const routes = [
     path: '/statistics',
     name: 'Statistics',
     component: StatisticsView,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/profile',
+    name: 'Profile',
+    component: ProfileView,
     meta: { requiresAuth: true }
   },
   {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -16,6 +16,13 @@
       >
         Ver Estadísticas
       </v-btn>
+      <v-btn
+        color="accent"
+        class="modern-btn full-btn mx-2"
+        @click="$router.push('/profile')"
+      >
+        Mi Perfil
+      </v-btn>
     </v-row>
     <hr />
     <!-- Buscador -->

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,0 +1,163 @@
+<template>
+  <v-container>
+    <!-- Button to return to dashboard -->
+    <v-row class="my-4" justify="center">
+      <v-btn color="primary" class="modern-btn full-btn" @click="$router.push('/dashboard')">
+        Volver al Dashboard
+      </v-btn>
+    </v-row>
+    <hr />
+
+    <!-- Profile Edit Card -->
+    <v-card class="mx-auto" max-width="600">
+      <v-card-title class="text-h6">Mi Perfil</v-card-title>
+      <v-card-text>
+        <v-form @submit.prevent="saveProfile">
+          <v-text-field v-model="player.name" label="Nombre" outlined />
+          <v-text-field v-model="player.lastName" label="Apellidos" outlined />
+          <v-text-field v-model="player.email" label="Correo" type="email" outlined />
+          <v-text-field v-model="player.password" label="Contraseña" type="password" outlined />
+          <v-text-field v-model="player.photo" label="Foto (URL)" outlined />
+          <v-btn type="submit" :loading="saving" :disabled="saving" class="modern-btn full-btn mt-4" color="secondary">
+            Guardar Cambios
+          </v-btn>
+        </v-form>
+      </v-card-text>
+    </v-card>
+
+    <!-- Reports List -->
+    <v-row class="mt-8" justify="center">
+      <v-col cols="12" md="8">
+        <h2 class="text-center">Reportes Creados</h2>
+        <v-list>
+          <v-list-item v-for="report in reports" :key="report.id">
+            <v-list-item-title>{{ formatDate(report.date) }} - {{ report.opponent?.name }}</v-list-item-title>
+            <template #append>
+              <v-btn icon color="error" @click="confirmDelete(report)">
+                <v-icon>mdi-delete</v-icon>
+              </v-btn>
+            </template>
+          </v-list-item>
+        </v-list>
+      </v-col>
+    </v-row>
+
+    <v-dialog v-model="deleteDialog" max-width="400">
+      <v-card>
+        <v-card-title class="text-h6">Confirmar Eliminación</v-card-title>
+        <v-card-text>
+          ¿Deseas eliminar este reporte?
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn text @click="deleteDialog = false">Cancelar</v-btn>
+          <v-btn text color="error" @click="deleteReportConfirmed">Eliminar</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script>
+import { getPlayerById, updatePlayer } from '@/services/playerService';
+import { getReportsByPlayer, deleteReport } from '@/services/reportService';
+
+export default {
+  data() {
+    return {
+      player: {},
+      reports: [],
+      saving: false,
+      deleteDialog: false,
+      reportToDelete: null,
+    };
+  },
+  created() {
+    this.fetchPlayer();
+    this.fetchReports();
+  },
+  methods: {
+    playerId() {
+      const sessionUser = sessionStorage.getItem('user');
+      if (!sessionUser) return null;
+      const user = JSON.parse(sessionUser);
+      return user.id ?? user.playerId ?? user.Id ?? user.ID;
+    },
+    async fetchPlayer() {
+      const id = this.playerId();
+      if (!id) return;
+      try {
+        const { data } = await getPlayerById(id);
+        this.player = { ...data };
+      } catch (err) {
+        console.error('Error fetching player', err);
+      }
+    },
+    async fetchReports() {
+      const id = this.playerId();
+      if (!id) return;
+      try {
+        const { data } = await getReportsByPlayer(id);
+        const rawReports = Array.isArray(data) ? data : data?.reports || [];
+        this.reports = rawReports.filter(r => r.playerAId === id);
+      } catch (err) {
+        console.error('Error fetching reports', err);
+      }
+    },
+    async saveProfile() {
+      this.saving = true;
+      const id = this.playerId();
+      try {
+        await updatePlayer(id, this.player);
+        sessionStorage.setItem('user', JSON.stringify(this.player));
+      } catch (err) {
+        console.error('Error updating player', err);
+      } finally {
+        this.saving = false;
+      }
+    },
+    confirmDelete(report) {
+      this.reportToDelete = report;
+      this.deleteDialog = true;
+    },
+    async deleteReportConfirmed() {
+      if (!this.reportToDelete) return;
+      try {
+        await deleteReport(this.reportToDelete.id);
+        this.reports = this.reports.filter(r => r.id !== this.reportToDelete.id);
+      } catch (err) {
+        console.error('Error deleting report', err);
+      } finally {
+        this.deleteDialog = false;
+        this.reportToDelete = null;
+      }
+    },
+    formatDate(date) {
+      const options = { year: 'numeric', month: '2-digit', day: '2-digit' };
+      return new Date(date).toLocaleDateString('es-ES', options);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modern-btn {
+  background: linear-gradient(135deg, #00f0ff, #7f00ff);
+  color: white;
+  font-weight: bold;
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.modern-btn:hover {
+  transform: scale(1.02);
+  box-shadow: 0 0 12px #7f00ff;
+}
+
+@media (max-width: 768px) {
+  .modern-btn {
+    width: 100%;
+    margin: 5px auto;
+  }
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add `ProfileView.vue` to allow editing player data and deleting owned reports
- register profile route in router
- add navigation button to Dashboard

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0355c384832197017089a50e0f00