### PR TITLE
Fix CORS issues with proxy and add auth header

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=/api

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://warapi.onrender.com

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,18 @@
 import axios from 'axios';
 
-// BaseURL apuntando directamente a la API desplegada
+// BaseURL configurable a través de variables de entorno para permitir
+// utilizar un proxy de desarrollo y así evitar problemas de CORS.
 const api = axios.create({
-  baseURL: 'https://warapi.onrender.com'
+  baseURL: import.meta.env.VITE_API_URL || '/api'
+});
+
+// Añadimos el token de autenticación a cada petición si está disponible
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
 });
 
 export default api;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,5 +13,15 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  server: {
+    // Proxy API requests durante el desarrollo para evitar problemas de CORS
+    proxy: {
+      '/api': {
+        target: 'https://warapi.onrender.com',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api/, '')
+      }
+    }
   }
 });


### PR DESCRIPTION
## Summary
- allow configuring API base URL via environment variables
- add a request interceptor to include the auth token
- setup Vite dev server proxy so local dev can bypass CORS
- add example `.env` files for development/production

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c0772f56083219a8e47646b5eb765