### PR TITLE
Fix sticky nav on report wizard

### DIFF
--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -230,7 +230,7 @@
       <v-divider></v-divider>
 
       <!-- Navegación -->
-      <v-card-actions>
+      <v-card-actions class="sticky-actions">
         <v-btn v-if="step > 1" variant="text" class="full-btn" @click="prevStep">
           Atrás
         </v-btn>
@@ -644,6 +644,13 @@ export default {
 .modern-btn:hover {
   transform: scale(1.02);
   box-shadow: 0 0 12px #7f00ff;
+}
+
+.sticky-actions {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--v-theme-surface, #121212);
+  z-index: 1;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- keep navigation actions visible at the bottom of the report wizard

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e2bd0a9b8832186af49c053053b3f