### PR TITLE
Add ChatBot configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ This repository contains the front-end of the WarApp project. The application is
 
 ## ChatGPT integration
 
-The magic step now includes an optional chatbot modal that connects directly to the OpenAI API. To enable it you must define an API key at build time:
+The magic step now includes an optional chatbot modal that connects directly to
+the OpenAI API. The API key is provided via the `ChatBotPass` environment variable at build time:
 
 ```
-VITE_OPENAI_API_KEY=your-key-here
+ChatBotPass=your-key-here
 ```
 
-You can set this value in `.env` during development or `.env.production` for a production build.
-
-Note that exposing an OpenAI API key in a public build is not recommended for production environments.
+You can set this value in `.env` during development or `.env.production` for a production build. Additional chatbot settings such as the endpoint or model are defined in `frontend/src/config/appsettings.json`.

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
 VITE_API_URL=/api
-VITE_OPENAI_API_KEY=
+ChatBotPass=

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
 VITE_API_URL=https://warapi.onrender.com
-VITE_OPENAI_API_KEY=
+ChatBotPass=

--- a/frontend/src/config/appsettings.json
+++ b/frontend/src/config/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "chatbot": {
+    "endpoint": "https://api.openai.com/v1/chat/completions",
+    "model": "gpt-3.5-turbo",
+    "systemPrompt": "Eres un experto en 9th Age y ayudas a los jugadores a resolver dudas."
+  }
+}

--- a/frontend/src/services/chatgptService.js
+++ b/frontend/src/services/chatgptService.js
@@ -1,20 +1,19 @@
 
 import axios from 'axios'
+import appsettings from '@/config/appsettings.json'
 
-// Direct call to the OpenAI API. The API key must be provided via the
-// `VITE_OPENAI_API_KEY` environment variable at build time.
-const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY
+// The OpenAI API key is provided through the `ChatBotPass` environment variable.
+const OPENAI_API_KEY = import.meta.env.ChatBotPass
 
 export const askChatGPT = ({ question }) => {
   return axios.post(
-    'https://api.openai.com/v1/chat/completions',
+    appsettings.chatbot.endpoint,
     {
-      model: 'gpt-3.5-turbo',
+      model: appsettings.chatbot.model,
       messages: [
         {
           role: 'system',
-          content:
-            'Eres un experto en 9th Age y ayudas a los jugadores a resolver dudas.',
+          content: appsettings.chatbot.systemPrompt,
         },
         { role: 'user', content: question },
       ],

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,8 @@ import { fileURLToPath, URL } from 'url';
 
 export default defineConfig({
   base: '/', // 👈 Esto es clave para Vite en producción
+  // Expose ChatBotPass environment variable to the client
+  envPrefix: ['VITE_', 'ChatBot'],
   plugins: [
     vue(),
     vuetify({ autoImport: true })


### PR DESCRIPTION
## Summary
- introduce `ChatBotPass` env var with fallback config in `appsettings.json`
- expose `ChatBotPass` via Vite envPrefix
- make ChatGPT service use the new config
- document new configuration approach

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2fba76dc8321ab963f72e2251412