### PR TITLE
Update login flow with player object

### DIFF
--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -45,7 +45,6 @@
 
 <script>
 import { login } from "@/services/authService";
-import { getPlayerByEmail } from "@/services/playerService";
 
 export default {
   data() {
@@ -65,15 +64,17 @@ export default {
           user: this.email,
           pass: this.password,
         });
-        localStorage.setItem("token", data.token);
 
-        const { data: userData } = await getPlayerByEmail(this.email);
-        if (userData) {
-          sessionStorage.setItem("user", JSON.stringify(userData));
-          this.$router.push("/dashboard");
-        } else {
-          throw new Error("Usuario no encontrado");
+        const token = data.token || data.Token;
+        if (token) {
+          localStorage.setItem("token", token);
         }
+
+        const player = data.player || data.user || data;
+        if (!player) throw new Error("Usuario no encontrado");
+
+        sessionStorage.setItem("user", JSON.stringify(player));
+        this.$router.push("/dashboard");
       } catch (err) {
         this.error =
           err.message ||

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -156,6 +156,7 @@ export default {
       if (!id) return;
       try {
         const { data } = await getPlayerById(id);
+        this.player.id = data.id || data.playerId || data.Id || data.ID;
         this.player.nombre = data.nombre || data.name || '';
         this.player.apellidos = data.apellidos || data.lastName || '';
         this.player.alias = data.alias || '';
@@ -187,11 +188,12 @@ export default {
       this.saveError = null;
       try {
         const payload = { ...this.player };
+        payload.id = payload.id || this.playerId();
         if (payload.foto && payload.foto.startsWith('data:')) {
           payload.foto = payload.foto.split(',')[1];
         }
         await updatePlayer(payload);
-        sessionStorage.setItem('user', JSON.stringify(this.player));
+        sessionStorage.setItem('user', JSON.stringify(payload));
         this.$router.push('/dashboard');
       } catch (err) {
         console.error('Error updating player', err);


### PR DESCRIPTION
## Summary
- use login response directly instead of extra request
- persist returned player in sessionStorage
- include player id when editing the profile

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ede3c9288321869d769f7b9b785a