### PR TITLE
Add autologin using session storage

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -58,6 +58,12 @@ const router = createRouter({
 // 👇 Protección de rutas privadas
 router.beforeEach((to, from, next) => {
   const token = localStorage.getItem('token')
+  const user = sessionStorage.getItem('user')
+
+  if (to.name === 'Login' && token && user) {
+    return next({ name: 'Dashboard' })
+  }
+
   if (to.meta.requiresAuth && !token) {
     return next({ name: 'Login' }) // redirige al login si no hay token
   }

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -55,6 +55,13 @@ export default {
       loading: false,
     };
   },
+  created() {
+    const token = localStorage.getItem("token");
+    const user = sessionStorage.getItem("user");
+    if (token && user) {
+      this.$router.push("/dashboard");
+    }
+  },
   methods: {
     async handleLogin() {
       this.error = null;


### PR DESCRIPTION
## Summary
- add router redirect to dashboard when login data is already stored
- redirect from LoginView when session info exists

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686110ed768483218d801854c387050b