### PR TITLE
Filter secondaries by army

### DIFF
--- a/frontend/src/mock/reportOptions.js
+++ b/frontend/src/mock/reportOptions.js
@@ -40,6 +40,86 @@ export const secondaries = [
   { name: "Work as One" }
 ];
 
+export const armySecondaryMap = {
+  "Beast Herds": ["Capture the Flags", "Commit to Battle", "Forbid Trespass"],
+  "Dread Elves": [
+    "Capture the Flags",
+    "Demonstrate Superiority",
+    "Enslave and Ransom"
+  ],
+  "Dwarven Holds": [
+    "Capture the Flags",
+    "Enslave and Ransom",
+    "Stand Firm"
+  ],
+  "Daemon Legions": [
+    "Capture the Flags",
+    "Master the Veil",
+    "Unleash the Big Guns"
+  ],
+  "Daemons of Change": [
+    "Capture the Flags",
+    "Master the Veil",
+    "Unleash the Big Guns"
+  ],
+  "Empire of Sonnstahl": [
+    "Demonstrate Superiority",
+    "Master the Veil",
+    "Unleash the Big Guns"
+  ],
+  "Highborn Elves": [
+    "Enslave and Ransom",
+    "Master the Veil",
+    "Stand Firm"
+  ],
+  "Kingdom of Equitaine": [
+    "Demonstrate Superiority",
+    "Forbid Trespass",
+    "Settle the Score"
+  ],
+  "Infernal Dwarves": [
+    "Commit to Battle",
+    "Settle the Score",
+    "Slay the Beast"
+  ],
+  "Ogre Khans": [
+    "Enslave and Ransom",
+    "Seize and Secure",
+    "Slay the Beast"
+  ],
+  "Orcs and Goblins": [
+    "Capture the Flags",
+    "Commit to Battle",
+    "Seize and Secure"
+  ],
+  "Saurian Ancients": [
+    "Forbid Trespass",
+    "Stand Firm",
+    "Unleash the Big Guns"
+  ],
+  "Sylvan Elves": ["Settle the Score", "Slay the Beast", "Work as One"],
+  "Undying Dynasties": [
+    "Master the Veil",
+    "Settle the Score",
+    "Work as One"
+  ],
+  "Vampire Covenant": [
+    "Master the Veil",
+    "Slay the Beast",
+    "Work as One"
+  ],
+  "Vermin Swarm": [
+    "Commit to Battle",
+    "Demonstrate Superiority",
+    "Work as One"
+  ],
+  "Warriors of the Dark Gods": [
+    "Commit to Battle",
+    "Demonstrate Superiority",
+    "Unleash the Big Guns"
+  ]
+};
+
 const magicOptions = [
   { value: 1, label: '1 - 4 Magic Dice' },
   { value: 2, label: '2 - 5 Magic Dice' },

--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -116,7 +116,7 @@
 
             <v-select
               v-model="selectedSecondaryPlayer"
-              :items="secondaries"
+              :items="filteredSecondariesPlayer"
               item-title="name"
               label="Misión Secundaria Jugador"
               outlined
@@ -125,7 +125,7 @@
 
             <v-select
               v-model="selectedSecondaryOpponent"
-              :items="secondaries"
+              :items="filteredSecondariesOpponent"
               item-title="name"
               label="Misión Secundaria Oponente"
               outlined
@@ -338,6 +338,7 @@ import {
   deployments,
   primaries,
   secondaries,
+  armySecondaryMap,
 } from "@/mock/reportOptions.js";
 import {
   createReport,
@@ -450,6 +451,18 @@ export default {
         this.selectedSecondaryOpponent
       );
     },
+    filteredSecondariesPlayer() {
+      const allowed = armySecondaryMap[this.player.army];
+      return allowed
+        ? this.secondaries.filter((s) => allowed.includes(s.name))
+        : this.secondaries;
+    },
+    filteredSecondariesOpponent() {
+      const allowed = armySecondaryMap[this.opponent.army];
+      return allowed
+        ? this.secondaries.filter((s) => allowed.includes(s.name))
+        : this.secondaries;
+    },
     canSaveReport() {
       return (
         this.playerComplete &&
@@ -511,6 +524,36 @@ export default {
       return `${basePlayerPoints}-${baseOpponentPoints}`;
     },
   },
+  watch: {
+    'player.id'(id) {
+      const p = this.players.find((pl) => pl.id === id);
+      this.player.army = p?.army || '';
+    },
+    'opponent.id'(id) {
+      const p = this.players.find((pl) => pl.id === id);
+      this.opponent.army = p?.army || '';
+    },
+    'player.army'() {
+      if (
+        this.selectedSecondaryPlayer &&
+        !this.filteredSecondariesPlayer.some(
+          (s) => s.name === this.selectedSecondaryPlayer.name
+        )
+      ) {
+        this.selectedSecondaryPlayer = null;
+      }
+    },
+    'opponent.army'() {
+      if (
+        this.selectedSecondaryOpponent &&
+        !this.filteredSecondariesOpponent.some(
+          (s) => s.name === this.selectedSecondaryOpponent.name
+        )
+      ) {
+        this.selectedSecondaryOpponent = null;
+      }
+    },
+  },
   methods: {
     async fetchPlayers() {
       try {
@@ -561,8 +604,8 @@ export default {
       this.selectedMap = rand(this.maps);
       this.selectedDeployment = rand(this.deployments);
       this.selectedPrimary = rand(this.primaries);
-      this.selectedSecondaryPlayer = rand(this.secondaries);
-      this.selectedSecondaryOpponent = rand(this.secondaries);
+      this.selectedSecondaryPlayer = rand(this.filteredSecondariesPlayer);
+      this.selectedSecondaryOpponent = rand(this.filteredSecondariesOpponent);
     },
     openPlayerDialog() {
       if (this.currentUser) {

--- a/frontend/src/views/EditReportView.vue
+++ b/frontend/src/views/EditReportView.vue
@@ -89,7 +89,7 @@
         />
         <v-select
           v-model="selectedSecondaryPlayer"
-          :items="secondaries"
+          :items="filteredSecondariesPlayer"
           item-title="name"
           label="Misión Secundaria Jugador"
           outlined
@@ -97,7 +97,7 @@
         />
         <v-select
           v-model="selectedSecondaryOpponent"
-          :items="secondaries"
+          :items="filteredSecondariesOpponent"
           item-title="name"
           label="Misión Secundaria Oponente"
           outlined
@@ -283,6 +283,7 @@ import {
   deployments,
   primaries,
   secondaries,
+  armySecondaryMap,
 } from '@/mock/reportOptions.js'
 import {
   createReport,
@@ -383,6 +384,18 @@ export default {
         this.selectedSecondaryOpponent
       )
     },
+    filteredSecondariesPlayer() {
+      const allowed = armySecondaryMap[this.player.army]
+      return allowed
+        ? this.secondaries.filter((s) => allowed.includes(s.name))
+        : this.secondaries
+    },
+    filteredSecondariesOpponent() {
+      const allowed = armySecondaryMap[this.opponent.army]
+      return allowed
+        ? this.secondaries.filter((s) => allowed.includes(s.name))
+        : this.secondaries
+    },
     canSaveReport() {
       return (
         this.playerComplete &&
@@ -440,6 +453,36 @@ export default {
       return `${basePlayerPoints}-${baseOpponentPoints}`
     },
   },
+  watch: {
+    'player.id'(id) {
+      const p = this.players.find((pl) => pl.id === id)
+      this.player.army = p?.army || ''
+    },
+    'opponent.id'(id) {
+      const p = this.players.find((pl) => pl.id === id)
+      this.opponent.army = p?.army || ''
+    },
+    'player.army'() {
+      if (
+        this.selectedSecondaryPlayer &&
+        !this.filteredSecondariesPlayer.some(
+          (s) => s.name === this.selectedSecondaryPlayer.name
+        )
+      ) {
+        this.selectedSecondaryPlayer = null
+      }
+    },
+    'opponent.army'() {
+      if (
+        this.selectedSecondaryOpponent &&
+        !this.filteredSecondariesOpponent.some(
+          (s) => s.name === this.selectedSecondaryOpponent.name
+        )
+      ) {
+        this.selectedSecondaryOpponent = null
+      }
+    },
+  },
   methods: {
     async fetchPlayers() {
       try {
@@ -490,8 +533,8 @@ export default {
       this.selectedMap = rand(this.maps)
       this.selectedDeployment = rand(this.deployments)
       this.selectedPrimary = rand(this.primaries)
-      this.selectedSecondaryPlayer = rand(this.secondaries)
-      this.selectedSecondaryOpponent = rand(this.secondaries)
+      this.selectedSecondaryPlayer = rand(this.filteredSecondariesPlayer)
+      this.selectedSecondaryOpponent = rand(this.filteredSecondariesOpponent)
     },
     openPlayerDialog() {
       if (this.currentUser) {


### PR DESCRIPTION
## Summary
- add `armySecondaryMap` mapping of armies to allowed secondary missions
- filter secondary mission selection for each player using their army
- update randomization logic to respect army restrictions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861153e418083218f0288042f512dd4