### PR TITLE
Add info modal for secondary missions

### DIFF
--- a/frontend/src/mock/reportOptions.js
+++ b/frontend/src/mock/reportOptions.js
@@ -26,18 +26,119 @@ export const primaries = [
 ];
 
 export const secondaries = [
-  { name: "Capture the Flags" },
-  { name: "Commit to Battle" },
-  { name: "Demonstrate Superiority" },
-  { name: "Enslave and Ransom" },
-  { name: "Forbid Trespass" },
-  { name: "Master the Veil" },
-  { name: "Seize and Secure" },
-  { name: "Settle the Score" },
-  { name: "Slay the Beast" },
-  { name: "Stand Firm" },
-  { name: "Unleash the Big Guns" },
-  { name: "Work as One" }
+  {
+    name: "Capture the Flags",
+    info: `Preparación: Ninguna.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, gana quien tenga más Portaestandartes y Portaestandartes de Batalla sobre el campo que el oponente.`
+  },
+  {
+    name: "Commit to Battle",
+    info: `Preparación: Ninguna.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, gana quien tenga más unidades Scoring en la zona de despliegue del oponente que el oponente en su propia zona.`
+  },
+  {
+    name: "Demonstrate Superiority",
+    info: `Preparación: El oponente nomina las dos unidades Scoring más caras de su ejército.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, gana quien logre que al menos una unidad nominada esté Destruida, Diezmada, Sacudida o tocando su propia zona de despliegue.`
+  },
+  {
+    name: "Enslave and Ransom",
+    info: `Preparación: Ninguna.
+
+Reglas:
+Ganas un Contador de Esclavitud cada vez que destruyes una unidad enemiga en combate cuerpo a cuerpo.
+Si la unidad es destruida al huir o al ser alcanzada tras una persecución, ganas un contador adicional.
+
+Condiciones de Victoria:
+Al final del juego, gana quien tenga al menos 4 Contadores de Esclavitud.`
+  },
+  {
+    name: "Forbid Trespass",
+    info: `Preparación: Nominas un Elemento de Terreno fuera de tu zona de despliegue.
+
+Reglas:
+Un Elemento de Terreno queda saqueado si una unidad Scoring enemiga inicia alguno de sus turnos (3–6) en contacto con él.
+
+Condiciones de Victoria:
+Al final del juego, ganas si el Elemento de Terreno nominado no fue saqueado.`
+  },
+  {
+    name: "Master the Veil",
+    info: `Preparación: Marca el centro del campo.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, ganas si tienes un modelo con Canalizar o que use un hechizo a 9” del centro del campo, y tu oponente no.`
+  },
+  {
+    name: "Seize and Secure",
+    info: `Preparación: El oponente nomina un Elemento de Terreno fuera de su zona de despliegue.
+
+Reglas:
+Un Elemento de Terreno queda saqueado si una unidad Scoring amiga inicia alguno de sus turnos (3–6) en contacto con él.
+
+Condiciones de Victoria:
+Al final del juego, ganas si saqueaste el Elemento de Terreno nominado.`
+  },
+  {
+    name: "Settle the Score",
+    info: `Preparación: Nombra una unidad del ejército del oponente.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, ganas si la unidad nominada está Destruida, Diezmada o Sacudida.`
+  },
+  {
+    name: "Slay the Beast",
+    info: `Preparación: El oponente nomina las dos unidades más caras que no sean Scoring de su ejército.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, ganas si al menos una unidad nominada está Destruida, Diezmada, Sacudida o tocando su propia zona de despliegue.`
+  },
+  {
+    name: "Stand Firm",
+    info: `Preparación: El oponente nomina dos unidades de Línea del ejército propio, preferiblemente Scoring.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, ganas si ambas unidades nominadas no están Destruidas, Diezmadas o Sacudidas.`
+  },
+  {
+    name: "Unleash the Big Guns",
+    info: `Preparación: Nomina dos Elementos de Terreno fuera de tu zona de despliegue. Marca todas las unidades no Scoring con armas de disparo y una unidad Scoring sin armas de disparo de tu ejército.
+Si tienes menos de 6 unidades marcadas, puedes marcar una unidad adicional Scoring.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, ganas si tienes una unidad marcada no Sacudida en ambos Elementos de Terreno nominados.`
+  },
+  {
+    name: "Work as One",
+    info: `Preparación: Marca el centro del campo.
+
+Reglas: Ninguna.
+
+Condiciones de Victoria:
+Al final del juego, ganas si tienes más unidades Scoring a 9” del centro del campo que tu oponente.`
+  }
 ];
 
 export const armySecondaryMap = {

--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -119,8 +119,11 @@
               :items="filteredSecondariesPlayer"
               item-title="name"
               label="Misión Secundaria Jugador"
+              return-object
               outlined
               class="mt-4"
+              append-inner-icon="mdi-information-outline"
+              @click:append-inner="openInfoDialog(selectedSecondaryPlayer?.info)"
             />
 
             <v-select
@@ -128,8 +131,11 @@
               :items="filteredSecondariesOpponent"
               item-title="name"
               label="Misión Secundaria Oponente"
+              return-object
               outlined
               class="mt-4"
+              append-inner-icon="mdi-information-outline"
+              @click:append-inner="openInfoDialog(selectedSecondaryOpponent?.info)"
             />
           </v-card-text>
         </v-window-item>


### PR DESCRIPTION
## Summary
- provide detailed info for each secondary mission in mock data
- allow opening info modal from secondary mission selects

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686117ed068c8321bca4758a8157697b