### PR TITLE
Filter secondaries by army

### DIFF
--- a/frontend/src/mock/reportOptions.js
+++ b/frontend/src/mock/reportOptions.js
@@ -221,6 +221,26 @@ export const armySecondaryMap = {
   ]
 };
 
+export const armies = [
+  "Beast Herds",
+  "Dread Elves",
+  "Dwarven Holds",
+  "Daemon Legions",
+  "Daemons of Change",
+  "Empire of Sonnstahl",
+  "Highborn Elves",
+  "Kingdom of Equitaine",
+  "Infernal Dwarves",
+  "Ogre Khans",
+  "Orcs and Goblins",
+  "Saurian Ancients",
+  "Sylvan Elves",
+  "Undying Dynasties",
+  "Vampire Covenant",
+  "Vermin Swarm",
+  "Warriors of the Dark Gods"
+];
+
 const magicOptions = [
   { value: 1, label: '1 - 4 Magic Dice' },
   { value: 2, label: '2 - 5 Magic Dice' },

--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -291,6 +291,13 @@
           />
           <v-textarea v-model="player.list" label="Lista" rows="6" outlined />
           <v-select
+            v-model="player.army"
+            :items="armies"
+            label="Ej\u00e9rcito"
+            outlined
+            class="mt-4"
+          />
+          <v-select
             v-model="expectedA"
             :items="expectedOptions"
             label="Resultado Esperado"
@@ -320,6 +327,13 @@
           />
           <v-textarea v-model="opponent.list" label="Lista" rows="6" outlined />
           <v-select
+            v-model="opponent.army"
+            :items="armies"
+            label="Ej\u00e9rcito"
+            outlined
+            class="mt-4"
+          />
+          <v-select
             v-model="expectedB"
             :items="expectedOptions"
             label="Resultado Esperado"
@@ -345,6 +359,7 @@ import {
   primaries,
   secondaries,
   armySecondaryMap,
+  armies,
 } from "@/mock/reportOptions.js";
 import {
   createReport,
@@ -373,6 +388,7 @@ export default {
       maps,
       deployments,
       primaries,
+      armies,
       secondaries,
       selectedMap: null,
       selectedDeployment: null,
@@ -565,6 +581,14 @@ export default {
       try {
         const { data } = await getAllPlayers();
         this.players = data;
+        if (this.player.id) {
+          const p = this.players.find((pl) => pl.id === this.player.id);
+          this.player.army = p?.army || this.player.army || '';
+        }
+        if (this.opponent.id) {
+          const p = this.players.find((pl) => pl.id === this.opponent.id);
+          this.opponent.army = p?.army || this.opponent.army || '';
+        }
       } catch (err) {
         console.error("Error fetching players", err);
       }

--- a/frontend/src/views/EditReportView.vue
+++ b/frontend/src/views/EditReportView.vue
@@ -230,6 +230,13 @@
           />
           <v-textarea v-model="player.list" label="Lista" rows="6" outlined />
           <v-select
+            v-model="player.army"
+            :items="armies"
+            label="Ej\u00e9rcito"
+            outlined
+            class="mt-4"
+          />
+          <v-select
             v-model="expectedA"
             :items="expectedOptions"
             label="Resultado Esperado"
@@ -259,6 +266,13 @@
           />
           <v-textarea v-model="opponent.list" label="Lista" rows="6" outlined />
           <v-select
+            v-model="opponent.army"
+            :items="armies"
+            label="Ej\u00e9rcito"
+            outlined
+            class="mt-4"
+          />
+          <v-select
             v-model="expectedB"
             :items="expectedOptions"
             label="Resultado Esperado"
@@ -284,6 +298,7 @@ import {
   primaries,
   secondaries,
   armySecondaryMap,
+  armies,
 } from '@/mock/reportOptions.js'
 import {
   createReport,
@@ -311,6 +326,7 @@ export default {
       maps,
       deployments,
       primaries,
+      armies,
       secondaries,
       selectedMap: null,
       selectedDeployment: null,
@@ -488,6 +504,14 @@ export default {
       try {
         const { data } = await getAllPlayers()
         this.players = data
+        if (this.player.id) {
+          const p = this.players.find((pl) => pl.id === this.player.id)
+          this.player.army = p?.army || this.player.army || ''
+        }
+        if (this.opponent.id) {
+          const p = this.players.find((pl) => pl.id === this.opponent.id)
+          this.opponent.army = p?.army || this.opponent.army || ''
+        }
       } catch (err) {
         console.error('Error fetching players', err)
       }


### PR DESCRIPTION
## Summary
- map each army to available secondary missions via `armies` constant
- refresh army info once players are loaded
- allow choosing army in report creation/edit dialogs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611b9958088321b14d0410af5f1a08