### PR TITLE
Auto-detect army on list upload

### DIFF
--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -555,6 +555,14 @@ export default {
       const p = this.players.find((pl) => pl.id === id);
       this.opponent.army = p?.army || '';
     },
+    'player.list'(list) {
+      const army = this.parseArmy(list);
+      if (army) this.player.army = army;
+    },
+    'opponent.list'(list) {
+      const army = this.parseArmy(list);
+      if (army) this.opponent.army = army;
+    },
     'player.army'() {
       if (
         this.selectedSecondaryPlayer &&
@@ -674,6 +682,14 @@ export default {
           !this.opponentMagic.includes(opt.value) ||
           this.opponentMagic[index] === opt.value
       );
+    },
+    parseArmy(list) {
+      if (!list) return null;
+      const firstLine = list.split(/\r?\n/)[0].trim();
+      if (!firstLine) return null;
+      const lineLower = firstLine.toLowerCase();
+      const found = this.armies.find((a) => lineLower.includes(a.toLowerCase()));
+      return found || null;
     },
     nextStep() {
       this.stepError = null;

--- a/frontend/src/views/EditReportView.vue
+++ b/frontend/src/views/EditReportView.vue
@@ -478,6 +478,14 @@ export default {
       const p = this.players.find((pl) => pl.id === id)
       this.opponent.army = p?.army || ''
     },
+    'player.list'(list) {
+      const army = this.parseArmy(list)
+      if (army) this.player.army = army
+    },
+    'opponent.list'(list) {
+      const army = this.parseArmy(list)
+      if (army) this.opponent.army = army
+    },
     'player.army'() {
       if (
         this.selectedSecondaryPlayer &&
@@ -593,6 +601,14 @@ export default {
       return this.magicOptions.filter(
         (opt) => !this.opponentMagic.includes(opt.value) || this.opponentMagic[index] === opt.value
       )
+    },
+    parseArmy(list) {
+      if (!list) return null
+      const firstLine = list.split(/\r?\n/)[0].trim()
+      if (!firstLine) return null
+      const lineLower = firstLine.toLowerCase()
+      const found = this.armies.find((a) => lineLower.includes(a.toLowerCase()))
+      return found || null
     },
     async saveReport() {
       this.saving = true


### PR DESCRIPTION
## Summary
- auto-populate army when a player list is pasted
- utility to detect the army from the first line of the list

## Testing
- `npm test` (fails: ENOENT)
- `npm test` inside frontend (fails: Missing script)
- `npm run build` inside frontend (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_68611fc207e883218801644fcd92e947