### PR TITLE
Show map/deployment images in info dialog

### DIFF
--- a/frontend/src/mock/reportOptions.js
+++ b/frontend/src/mock/reportOptions.js
@@ -1,19 +1,67 @@
 export const maps = [
-  { name: "Clearwater Springs", info: "Map 1 – Clearwater Springs" },
-  { name: "Ancient Fortifications", info: "Map 2 – Ancient Fortifications" },
-  { name: "Dormant Caldera", info: "Map 3 – Dormant Caldera" },
-  { name: "Abandoned Settlement", info: "Map 4 – Abandoned Settlement" },
-  { name: "Historic Battlefield", info: "Map 5 – Historic Battlefield" },
-  { name: "Mountainous Crags", info: "Map 6 – Mountainous Crags" }
+  {
+    name: "Clearwater Springs",
+    info: "Map 1 – Clearwater Springs",
+    image: "/deploys/1 - Mapa.png",
+  },
+  {
+    name: "Ancient Fortifications",
+    info: "Map 2 – Ancient Fortifications",
+    image: "/deploys/2 - Mapa.png",
+  },
+  {
+    name: "Dormant Caldera",
+    info: "Map 3 – Dormant Caldera",
+    image: "/deploys/3 - Mapa.png",
+  },
+  {
+    name: "Abandoned Settlement",
+    info: "Map 4 – Abandoned Settlement",
+    image: "/deploys/4 - Mapa.png",
+  },
+  {
+    name: "Historic Battlefield",
+    info: "Map 5 – Historic Battlefield",
+    image: "/deploys/5 - Mapa.png",
+  },
+  {
+    name: "Mountainous Crags",
+    info: "Map 6 – Mountainous Crags",
+    image: "/deploys/6 - Mapa.png",
+  },
 ];
 
 export const deployments = [
-  { name: "Frontline Clash" },
-  { name: "Bottleneck" },
-  { name: "Spearhead" },
-  { name: "Mutual Encroachment" },
-  { name: "Refused Flank" },
-  { name: "Cornerstone" }
+  {
+    name: "Frontline Clash",
+    info: "Deployment 1 – Frontline Clash",
+    image: "/deploys/1 - Despliegue.png",
+  },
+  {
+    name: "Bottleneck",
+    info: "Deployment 2 – Bottleneck",
+    image: "/deploys/2 - Despliegue.png",
+  },
+  {
+    name: "Spearhead",
+    info: "Deployment 3 – Spearhead",
+    image: "/deploys/3 - Despliegue.png",
+  },
+  {
+    name: "Mutual Encroachment",
+    info: "Deployment 4 – Mutual Encroachment",
+    image: "/deploys/4 - Despliegue.png",
+  },
+  {
+    name: "Refused Flank",
+    info: "Deployment 5 – Refused Flank",
+    image: "/deploys/5 - Despliegue.png",
+  },
+  {
+    name: "Cornerstone",
+    info: "Deployment 6 – Cornerstone",
+    image: "/deploys/6 - Despliegue.png",
+  },
 ];
 
 

--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -90,7 +90,7 @@
               outlined
               class="mt-4"
               append-inner-icon="mdi-information-outline"
-              @click:append-inner="openInfoDialog(selectedMap?.info)"
+              @click:append-inner="openInfoDialog(selectedMap?.info, selectedMap?.image)"
             />
 
             <v-select
@@ -100,6 +100,8 @@
               label="Despliegue"
               outlined
               class="mt-4"
+              append-inner-icon="mdi-information-outline"
+              @click:append-inner="openInfoDialog(selectedDeployment?.info, selectedDeployment?.image)"
             />
 
             <v-select
@@ -280,7 +282,10 @@
     <v-dialog v-model="infoDialog" max-width="500px">
       <v-card>
         <v-card-title>Información</v-card-title>
-        <v-card-text>{{ currentInfo }}</v-card-text>
+        <v-card-text>
+          <v-img v-if="currentImage" :src="currentImage" class="mb-2" />
+          {{ currentInfo }}
+        </v-card-text>
         <v-card-actions>
           <v-spacer />
           <v-btn text @click="infoDialog = false">Cerrar</v-btn>
@@ -406,6 +411,7 @@ export default {
       selectedSecondaryOpponent: null,
       infoDialog: false,
       currentInfo: "",
+      currentImage: "",
       magicOptions: [
         { value: 1, label: "1 - 4 Magic Dice" },
         { value: 2, label: "2 - 5 Magic Dice" },
@@ -678,8 +684,9 @@ export default {
     saveOpponent() {
       this.opponentDialog = false;
     },
-    openInfoDialog(info) {
+    openInfoDialog(info, image) {
       this.currentInfo = info;
+      this.currentImage = image || "";
       this.infoDialog = true;
     },
     magicOptionsForPlayerA(index) {

--- a/frontend/src/views/EditReportView.vue
+++ b/frontend/src/views/EditReportView.vue
@@ -66,7 +66,7 @@
           outlined
           class="mt-4"
           append-inner-icon="mdi-information-outline"
-          @click:append-inner="openInfoDialog(selectedMap?.info)"
+          @click:append-inner="openInfoDialog(selectedMap?.info, selectedMap?.image)"
         />
         <v-select
           v-model="selectedDeployment"
@@ -75,6 +75,8 @@
           label="Despliegue"
           outlined
           class="mt-4"
+          append-inner-icon="mdi-information-outline"
+          @click:append-inner="openInfoDialog(selectedDeployment?.info, selectedDeployment?.image)"
         />
         <v-select
           v-model="selectedPrimary"
@@ -210,7 +212,10 @@
     <v-dialog v-model="infoDialog" max-width="500px">
       <v-card>
         <v-card-title>Información</v-card-title>
-        <v-card-text>{{ currentInfo }}</v-card-text>
+        <v-card-text>
+          <v-img v-if="currentImage" :src="currentImage" class="mb-2" />
+          {{ currentInfo }}
+        </v-card-text>
         <v-card-actions>
           <v-spacer />
           <v-btn text @click="infoDialog = false">Cerrar</v-btn>
@@ -335,6 +340,7 @@ export default {
       selectedSecondaryOpponent: null,
       infoDialog: false,
       currentInfo: '',
+      currentImage: '',
       magicOptions: [
         { value: 1, label: '1 - 4 Magic Dice' },
         { value: 2, label: '2 - 5 Magic Dice' },
@@ -588,8 +594,9 @@ export default {
     saveOpponent() {
       this.opponentDialog = false
     },
-    openInfoDialog(info) {
+    openInfoDialog(info, image) {
       this.currentInfo = info
+      this.currentImage = image || ''
       this.infoDialog = true
     },
     magicOptionsForPlayerA(index) {


### PR DESCRIPTION
## Summary
- attach numbered map and deployment images to report options
- let users see these images in Create/Edit report when they click info

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612cbfdca48321a92ccd2fda38afba