### PR TITLE
Store login token in session storage

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,12 +20,12 @@
 export default {
   computed: {
     isAuthenticated() {
-      return !!localStorage.getItem("token");
+      return !!sessionStorage.getItem("token");
     },
   },
   methods: {
     logout() {
-      localStorage.removeItem("token");
+      sessionStorage.removeItem("token");
       sessionStorage.removeItem("user");
       this.$router.push("/"); // 👈 A la raíz
     },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -57,7 +57,7 @@ const router = createRouter({
 
 // 👇 Protección de rutas privadas
 router.beforeEach((to, from, next) => {
-  const token = localStorage.getItem('token')
+  const token = sessionStorage.getItem('token')
   const user = sessionStorage.getItem('user')
 
   if (to.name === 'Login' && token && user) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -8,11 +8,16 @@ const api = axios.create({
 
 // Añadimos el token de autenticación a cada petición si está disponible
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
+  const token = sessionStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
+
+export const authHeaders = () => {
+  const token = sessionStorage.getItem('token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export default api;

--- a/frontend/src/services/playerService.js
+++ b/frontend/src/services/playerService.js
@@ -1,9 +1,9 @@
-import api from './api';
+import api, { authHeaders } from './api';
 
-export const getAllPlayers = () => api.get('/Player');
-export const createPlayer = (player) => api.post('/Player', player);
-export const deletePlayer = (id) => api.delete(`/Player/${id}`);
-export const getPlayerByEmail = (email) => api.get(`/Player/GetByEmail?email=${email}`);
-export const getPlayerById = (id) => api.get(`/Player/${id}`);
-export const updatePlayer = (player) => api.put('/Player', player);
+export const getAllPlayers = () => api.get('/Player', { headers: authHeaders() });
+export const createPlayer = (player) => api.post('/Player', player, { headers: authHeaders() });
+export const deletePlayer = (id) => api.delete(`/Player/${id}`, { headers: authHeaders() });
+export const getPlayerByEmail = (email) => api.get(`/Player/GetByEmail?email=${email}`, { headers: authHeaders() });
+export const getPlayerById = (id) => api.get(`/Player/${id}`, { headers: authHeaders() });
+export const updatePlayer = (player) => api.put('/Player', player, { headers: authHeaders() });
 

--- a/frontend/src/services/playerStatsService.js
+++ b/frontend/src/services/playerStatsService.js
@@ -1,26 +1,26 @@
-import api from './api';
+import api, { authHeaders } from './api';
 
 export const getTotal = (playerId) =>
-  api.get(`/api/PlayerStats/${playerId}/total`);
+  api.get(`/api/PlayerStats/${playerId}/total`, { headers: authHeaders() });
 export const getWins = (playerId) =>
-  api.get(`/api/PlayerStats/${playerId}/wins`);
+  api.get(`/api/PlayerStats/${playerId}/wins`, { headers: authHeaders() });
 export const getLosses = (playerId) =>
-  api.get(`/api/PlayerStats/${playerId}/losses`);
+  api.get(`/api/PlayerStats/${playerId}/losses`, { headers: authHeaders() });
 export const getDraws = (playerId) =>
-  api.get(`/api/PlayerStats/${playerId}/draws`);
+  api.get(`/api/PlayerStats/${playerId}/draws`, { headers: authHeaders() });
 export const getGamesByArmy = (playerId, army) =>
-  api.get(`/api/PlayerStats/${playerId}/army/${army}/total`);
+  api.get(`/api/PlayerStats/${playerId}/army/${army}/total`, { headers: authHeaders() });
 export const getWinsByArmy = (playerId, army) =>
-  api.get(`/api/PlayerStats/${playerId}/army/${army}/wins`);
+  api.get(`/api/PlayerStats/${playerId}/army/${army}/wins`, { headers: authHeaders() });
 export const getMapWinRate = (playerId, map) =>
-  api.get(`/api/PlayerStats/${playerId}/map/${map}/winrate`);
+  api.get(`/api/PlayerStats/${playerId}/map/${map}/winrate`, { headers: authHeaders() });
 export const getDeploymentWinRate = (playerId, deployment) =>
-  api.get(`/api/PlayerStats/${playerId}/deployment/${deployment}/winrate`);
+  api.get(`/api/PlayerStats/${playerId}/deployment/${deployment}/winrate`, { headers: authHeaders() });
 export const getPrimaryWinRate = (playerId, mission) =>
-  api.get(`/api/PlayerStats/${playerId}/primary/${mission}/winrate`);
+  api.get(`/api/PlayerStats/${playerId}/primary/${mission}/winrate`, { headers: authHeaders() });
 export const getBestOpponent = (playerId) =>
-  api.get(`/api/PlayerStats/${playerId}/best-opponent`);
+  api.get(`/api/PlayerStats/${playerId}/best-opponent`, { headers: authHeaders() });
 export const getWorstOpponent = (playerId) =>
-  api.get(`/api/PlayerStats/${playerId}/worst-opponent`);
+  api.get(`/api/PlayerStats/${playerId}/worst-opponent`, { headers: authHeaders() });
 export const getIdealScenario = (playerId, top = 1) =>
-  api.get(`/api/PlayerStats/${playerId}/ideal-scenario/${top}`);
+  api.get(`/api/PlayerStats/${playerId}/ideal-scenario/${top}`, { headers: authHeaders() });

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -1,11 +1,11 @@
-import api from './api';
+import api, { authHeaders } from './api';
 
-export const getAllReports = () => api.get('/api/MatchReports');
-export const createReport = (report) => api.post('/api/MatchReports', report);
-export const getReportById = (id) => api.get(`/api/MatchReports/${id}`);
+export const getAllReports = () => api.get('/api/MatchReports', { headers: authHeaders() });
+export const createReport = (report) => api.post('/api/MatchReports', report, { headers: authHeaders() });
+export const getReportById = (id) => api.get(`/api/MatchReports/${id}`, { headers: authHeaders() });
 export const getReportsByPlayer = (playerId) =>
-  api.get(`/api/MatchReports/GetByPlayerId?playerId=${playerId}`);
+  api.get(`/api/MatchReports/GetByPlayerId?playerId=${playerId}`, { headers: authHeaders() });
 export const updateReport = (id, report) =>
-  api.put(`/api/MatchReports/${id}`, report);
-export const deleteReport = (id) => api.delete(`/api/MatchReports/${id}`);
+  api.put(`/api/MatchReports/${id}`, report, { headers: authHeaders() });
+export const deleteReport = (id) => api.delete(`/api/MatchReports/${id}`, { headers: authHeaders() });
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -56,7 +56,7 @@ export default {
     };
   },
   created() {
-    const token = localStorage.getItem("token");
+    const token = sessionStorage.getItem("token");
     const user = sessionStorage.getItem("user");
     if (token && user) {
       this.$router.push("/dashboard");
@@ -74,7 +74,7 @@ export default {
 
         const token = data.token || data.Token;
         if (token) {
-          localStorage.setItem("token", token);
+          sessionStorage.setItem("token", token);
         }
 
         const player = data.player || data.user || data;


### PR DESCRIPTION
## Summary
- keep token in sessionStorage instead of localStorage
- use token from session storage on every API service call
- update login flow, app auth check and router guard

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637863c6b08321a57f0c66f5ac47a3