### PR TITLE
Add team management view with role-based access

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -7,6 +7,7 @@ import CreateReportView from '@/views/CreateReportView.vue'
 import EditReportView from '@/views/EditReportView.vue'
 import StatisticsView from '@/views/StatisticsView.vue'
 import ProfileView from '@/views/ProfileView.vue'
+import TeamManagementView from '@/views/TeamManagementView.vue'
 
 const routes = [
   {
@@ -45,6 +46,12 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
+    path: '/team-management',
+    name: 'TeamManagement',
+    component: TeamManagementView,
+    meta: { requiresAuth: true, allowedRoles: [1, 2, 3] }
+  },
+  {
     path: '/:pathMatch(.*)*',
     redirect: '/'          // 👈 cualquier ruta inválida vuelve al login
   }
@@ -66,6 +73,19 @@ router.beforeEach((to, from, next) => {
 
   if (to.meta.requiresAuth && !token) {
     return next({ name: 'Login' }) // redirige al login si no hay token
+  }
+
+  if (to.meta.allowedRoles) {
+    if (!user) {
+      return next({ name: 'Login' })
+    }
+    const u = JSON.parse(user)
+    const role = Number(
+      u.role ?? u.rol ?? u.roleId ?? u.rolId ?? u.Role ?? u.Rol ?? u.RoleID ?? u.RolID ?? 0
+    )
+    if (!to.meta.allowedRoles.includes(role)) {
+      return next({ name: 'Dashboard' })
+    }
   }
   next()
 })

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -23,6 +23,14 @@
       >
         Mi Perfil
       </v-btn>
+      <v-btn
+        v-if="[1, 2, 3].includes(userRole)"
+        color="warning"
+        class="modern-btn full-btn mx-2"
+        @click="$router.push('/team-management')"
+      >
+        Gestión de Equipo
+      </v-btn>
     </v-row>
     <hr />
     <!-- Buscador -->
@@ -256,6 +264,14 @@ export default {
     };
   },
   computed: {
+    userRole() {
+      const sessionUser = sessionStorage.getItem('user')
+      if (!sessionUser) return null
+      const u = JSON.parse(sessionUser)
+      return Number(
+        u.role ?? u.rol ?? u.roleId ?? u.rolId ?? u.Role ?? u.Rol ?? u.RoleID ?? u.RolID ?? 0
+      )
+    },
     filteredReports() {
       if (!this.searchQuery) {
         return this.visibleReports;

--- a/frontend/src/views/TeamManagementView.vue
+++ b/frontend/src/views/TeamManagementView.vue
@@ -1,0 +1,188 @@
+<template>
+  <v-container>
+    <!-- Return button -->
+    <v-row class="my-4" justify="center">
+      <v-btn color="primary" class="modern-btn full-btn" @click="$router.push('/dashboard')">
+        Volver al Dashboard
+      </v-btn>
+    </v-row>
+    <hr />
+
+    <v-row>
+      <!-- Create Player Form -->
+      <v-col cols="12" md="4">
+        <v-card>
+          <v-card-title>Crear Nuevo Jugador</v-card-title>
+          <v-card-text>
+            <v-form @submit.prevent="createPlayerSubmit">
+              <v-text-field v-model="newPlayer.nombre" label="Nombre" required />
+              <v-text-field v-model="newPlayer.apellidos" label="Apellidos" required />
+              <v-text-field v-model="newPlayer.alias" label="Alias" required />
+              <v-text-field v-model="newPlayer.email" label="Correo" required />
+              <v-text-field v-model="newPlayer.contraseña" label="Contraseña" type="password" required />
+              <v-btn type="submit" color="primary" class="modern-btn full-btn mt-2" :loading="creating" :disabled="creating">
+                Crear
+              </v-btn>
+              <v-alert v-if="createError" type="error" class="mt-2">{{ createError }}</v-alert>
+            </v-form>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <!-- Team Statistics -->
+      <v-col cols="12" md="8">
+        <v-card>
+          <v-card-title>Estadísticas del Equipo</v-card-title>
+          <v-card-text>
+            <v-select
+              v-model="selectedPlayers"
+              :items="players"
+              item-title="alias"
+              item-value="id"
+              multiple
+              clearable
+              label="Filtrar jugadores"
+            />
+            <v-table class="mt-4">
+              <thead>
+                <tr>
+                  <th>Jugador</th>
+                  <th>Partidas</th>
+                  <th>Victorias</th>
+                  <th>Derrotas</th>
+                  <th>Empates</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="stat in filteredStats" :key="stat.player.id">
+                  <td>{{ stat.player.alias }}</td>
+                  <td>{{ stat.games }}</td>
+                  <td>{{ stat.wins }}</td>
+                  <td>{{ stat.losses }}</td>
+                  <td>{{ stat.draws }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { getAllPlayers, createPlayer } from '@/services/playerService'
+import { getReportsByPlayer } from '@/services/reportService'
+
+export default {
+  data() {
+    return {
+      players: [],
+      playerStats: [],
+      selectedPlayers: [],
+      newPlayer: {
+        nombre: '',
+        apellidos: '',
+        alias: '',
+        email: '',
+        contraseña: ''
+      },
+      creating: false,
+      createError: null
+    }
+  },
+  computed: {
+    filteredStats() {
+      if (!this.selectedPlayers.length) {
+        return this.playerStats
+      }
+      return this.playerStats.filter(s => this.selectedPlayers.includes(s.player.id))
+    }
+  },
+  created() {
+    this.fetchPlayers()
+  },
+  methods: {
+    getUserTeam() {
+      const sessionUser = sessionStorage.getItem('user')
+      if (!sessionUser) return ''
+      const user = JSON.parse(sessionUser)
+      return user.equipo || user.team || ''
+    },
+    async fetchPlayers() {
+      try {
+        const { data } = await getAllPlayers()
+        const list = Array.isArray(data) ? data : data?.players || []
+        const team = this.getUserTeam()
+        this.players = list.filter(p => (p.equipo || p.team) === team)
+        await this.computeStats()
+      } catch (err) {
+        console.error('Error fetching players', err)
+      }
+    },
+    async computeStats() {
+      const stats = []
+      for (const p of this.players) {
+        try {
+          const playerId = p.id ?? p.playerId ?? p.Id ?? p.ID
+          const { data } = await getReportsByPlayer(playerId)
+          const raw = Array.isArray(data) ? data : data?.reports || []
+          let wins = 0
+          let losses = 0
+          let draws = 0
+          raw.forEach(r => {
+            const isA = r.playerAId === playerId
+            const scorePlayer = isA ? r.finalScoreA : r.finalScoreB
+            const scoreOpp = isA ? r.finalScoreB : r.finalScoreA
+            if (scorePlayer > scoreOpp) wins++
+            else if (scorePlayer < scoreOpp) losses++
+            else draws++
+          })
+          stats.push({ player: p, games: raw.length, wins, losses, draws })
+        } catch (err) {
+          console.error('Error stats player', err)
+        }
+      }
+      this.playerStats = stats
+    },
+    async createPlayerSubmit() {
+      this.createError = null
+      this.creating = true
+      try {
+        const team = this.getUserTeam()
+        const payload = { ...this.newPlayer, equipo: team, team }
+        await createPlayer(payload)
+        this.newPlayer = { nombre: '', apellidos: '', alias: '', email: '', contraseña: '' }
+        await this.fetchPlayers()
+      } catch (err) {
+        console.error('Error creating player', err)
+        this.createError = 'Error creando jugador'
+      } finally {
+        this.creating = false
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.modern-btn {
+  background: linear-gradient(135deg, #00f0ff, #7f00ff);
+  color: white;
+  font-weight: bold;
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.modern-btn:hover {
+  transform: scale(1.02);
+  box-shadow: 0 0 12px #7f00ff;
+}
+
+@media (max-width: 768px) {
+  .modern-btn {
+    width: 100%;
+    margin: 5px auto;
+  }
+}
+</style>
+


### PR DESCRIPTION
## Summary
- create new `TeamManagementView` to manage players in a team
- allow roles 1-3 to access the new view via router guard
- show navigation button for allowed roles on dashboard
- enforce role checks in router

## Testing
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found due to missing deps)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863d159038c8321a1e5ed25bbdff66b