### PR TITLE
Implement separate team management views

### DIFF
--- a/frontend/src/components/TeamStats.vue
+++ b/frontend/src/components/TeamStats.vue
@@ -1,0 +1,151 @@
+<template>
+  <div>
+    <v-row class="mb-4" justify="center">
+      <v-col cols="12" md="4" class="d-flex">
+        <v-card class="flex-grow-1">
+          <v-card-title class="text-center">Partidas Jugadas</v-card-title>
+          <v-card-text class="text-center">
+            <span class="text-h4">{{ totalGames }}</span>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <v-col cols="12" md="4" class="d-flex">
+        <v-card class="flex-grow-1">
+          <v-card-title class="text-center">Resultados</v-card-title>
+          <v-card-text class="text-center">
+            <div>🏆 Victorias: {{ totalWins }}</div>
+            <div>⚖️ Empates: {{ totalDraws }}</div>
+            <div>❌ Derrotas: {{ totalLosses }}</div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col cols="12" md="6">
+        <v-card>
+          <v-card-title>Distribución Resultados</v-card-title>
+          <v-card-text>
+            <canvas :id="`resultsChart-${playerId}`"></canvas>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="6">
+        <v-card>
+          <v-card-title>Mapas más Jugados</v-card-title>
+          <v-card-text>
+            <canvas :id="`mapsChart-${playerId}`"></canvas>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+import Chart from 'chart.js/auto'
+import { getReportsByPlayer } from '@/services/reportService'
+
+export default {
+  props: {
+    playerId: {
+      type: [Number, String],
+      required: true
+    }
+  },
+  data() {
+    return {
+      reports: []
+    }
+  },
+  computed: {
+    totalGames() {
+      return this.reports.length
+    },
+    totalWins() {
+      return this.reports.filter(r => this.isWin(r)).length
+    },
+    totalLosses() {
+      return this.reports.filter(r => this.isLoss(r)).length
+    },
+    totalDraws() {
+      return this.reports.filter(r => this.isDraw(r)).length
+    },
+    topMaps() {
+      const counts = {}
+      this.reports.forEach(r => {
+        counts[r.map] = (counts[r.map] || 0) + 1
+      })
+      return Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+    }
+  },
+  methods: {
+    isWin(report) {
+      const [a, b] = report.finalScore.split('-').map(Number)
+      return a > b
+    },
+    isLoss(report) {
+      const [a, b] = report.finalScore.split('-').map(Number)
+      return a < b
+    },
+    isDraw(report) {
+      const [a, b] = report.finalScore.split('-').map(Number)
+      return a === b
+    },
+    setupCharts() {
+      const ctx1 = document.getElementById(`resultsChart-${this.playerId}`)
+      new Chart(ctx1, {
+        type: 'doughnut',
+        data: {
+          labels: ['Victorias', 'Derrotas', 'Empates'],
+          datasets: [{
+            data: [this.totalWins, this.totalLosses, this.totalDraws],
+            backgroundColor: ['#00bfff', '#6a0dad', '#ffef00']
+          }]
+        }
+      })
+
+      const ctx2 = document.getElementById(`mapsChart-${this.playerId}`)
+      new Chart(ctx2, {
+        type: 'bar',
+        data: {
+          labels: this.topMaps.map(m => m[0]),
+          datasets: [{
+            label: 'Veces Jugado',
+            data: this.topMaps.map(m => m[1]),
+            backgroundColor: '#00bfff'
+          }]
+        }
+      })
+    },
+    async fetchReports() {
+      try {
+        const { data } = await getReportsByPlayer(this.playerId)
+        const raw = Array.isArray(data) ? data : data?.reports || []
+        this.reports = raw.map(r => {
+          const isA = r.playerAId === this.playerId
+          return {
+            map: r.map,
+            finalScore: `${isA ? r.finalScoreA : r.finalScoreB}-${isA ? r.finalScoreB : r.finalScoreA}`
+          }
+        })
+        this.$nextTick(() => this.setupCharts())
+      } catch (err) {
+        console.error('Error fetching reports', err)
+      }
+    }
+  },
+  mounted() {
+    this.fetchReports()
+  }
+}
+</script>
+
+<style scoped>
+.v-card-title {
+  font-weight: bold;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -7,7 +7,8 @@ import CreateReportView from '@/views/CreateReportView.vue'
 import EditReportView from '@/views/EditReportView.vue'
 import StatisticsView from '@/views/StatisticsView.vue'
 import ProfileView from '@/views/ProfileView.vue'
-import TeamManagementView from '@/views/TeamManagementView.vue'
+import TeamOverviewView from '@/views/TeamOverviewView.vue'
+import CreatePlayerView from '@/views/CreatePlayerView.vue'
 
 const routes = [
   {
@@ -46,10 +47,20 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
-    path: '/team-management',
-    name: 'TeamManagement',
-    component: TeamManagementView,
+    path: '/team-management/overview',
+    name: 'TeamOverview',
+    component: TeamOverviewView,
     meta: { requiresAuth: true, allowedRoles: [1, 2, 3] }
+  },
+  {
+    path: '/team-management/create-player',
+    name: 'CreatePlayer',
+    component: CreatePlayerView,
+    meta: { requiresAuth: true, allowedRoles: [1, 2, 3] }
+  },
+  {
+    path: '/team-management',
+    redirect: '/team-management/overview'
   },
   {
     path: '/:pathMatch(.*)*',

--- a/frontend/src/views/CreatePlayerView.vue
+++ b/frontend/src/views/CreatePlayerView.vue
@@ -1,0 +1,98 @@
+<template>
+  <v-container>
+    <!-- Return button -->
+    <v-row class="my-4" justify="center">
+      <v-btn color="primary" class="modern-btn full-btn" @click="$router.push('/dashboard')">
+        Volver al Dashboard
+      </v-btn>
+    </v-row>
+    <hr />
+
+    <v-row>
+      <!-- Create Player Form -->
+      <v-col cols="12" md="6" offset-md="3">
+        <v-card>
+          <v-card-title>Crear Nuevo Jugador</v-card-title>
+          <v-card-text>
+            <v-form @submit.prevent="createPlayerSubmit">
+              <v-text-field v-model="newPlayer.nombre" label="Nombre" required />
+              <v-text-field v-model="newPlayer.apellidos" label="Apellidos" required />
+              <v-text-field v-model="newPlayer.alias" label="Alias" required />
+              <v-text-field v-model="newPlayer.email" label="Correo" required />
+              <v-text-field v-model="newPlayer.contraseña" label="Contraseña" type="password" required />
+              <v-btn type="submit" color="primary" class="modern-btn full-btn mt-2" :loading="creating" :disabled="creating">
+                Crear
+              </v-btn>
+              <v-alert v-if="createError" type="error" class="mt-2">{{ createError }}</v-alert>
+            </v-form>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { createPlayer } from '@/services/playerService'
+
+export default {
+  data() {
+    return {
+      newPlayer: {
+        nombre: '',
+        apellidos: '',
+        alias: '',
+        email: '',
+        contraseña: ''
+      },
+      creating: false,
+      createError: null
+    }
+  },
+  methods: {
+    getUserTeam() {
+      const sessionUser = sessionStorage.getItem('user')
+      if (!sessionUser) return ''
+      const user = JSON.parse(sessionUser)
+      return user.equipo || user.team || ''
+    },
+    async createPlayerSubmit() {
+      this.createError = null
+      this.creating = true
+      try {
+        const team = this.getUserTeam()
+        const payload = { ...this.newPlayer, equipo: team, team }
+        await createPlayer(payload)
+        this.newPlayer = { nombre: '', apellidos: '', alias: '', email: '', contraseña: '' }
+      } catch (err) {
+        console.error('Error creating player', err)
+        this.createError = 'Error creando jugador'
+      } finally {
+        this.creating = false
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.modern-btn {
+  background: linear-gradient(135deg, #00f0ff, #7f00ff);
+  color: white;
+  font-weight: bold;
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.modern-btn:hover {
+  transform: scale(1.02);
+  box-shadow: 0 0 12px #7f00ff;
+}
+
+@media (max-width: 768px) {
+  .modern-btn {
+    width: 100%;
+    margin: 5px auto;
+  }
+}
+</style>
+

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -27,7 +27,7 @@
         v-if="[1, 2, 3].includes(userRole)"
         color="warning"
         class="modern-btn full-btn mx-2"
-        @click="$router.push('/team-management')"
+        @click="$router.push('/team-management/overview')"
       >
         Gestión de Equipo
       </v-btn>

--- a/frontend/src/views/TeamOverviewView.vue
+++ b/frontend/src/views/TeamOverviewView.vue
@@ -9,28 +9,11 @@
     <hr />
 
     <v-row>
-      <!-- Create Player Form -->
-      <v-col cols="12" md="4">
-        <v-card>
-          <v-card-title>Crear Nuevo Jugador</v-card-title>
-          <v-card-text>
-            <v-form @submit.prevent="createPlayerSubmit">
-              <v-text-field v-model="newPlayer.nombre" label="Nombre" required />
-              <v-text-field v-model="newPlayer.apellidos" label="Apellidos" required />
-              <v-text-field v-model="newPlayer.alias" label="Alias" required />
-              <v-text-field v-model="newPlayer.email" label="Correo" required />
-              <v-text-field v-model="newPlayer.contraseña" label="Contraseña" type="password" required />
-              <v-btn type="submit" color="primary" class="modern-btn full-btn mt-2" :loading="creating" :disabled="creating">
-                Crear
-              </v-btn>
-              <v-alert v-if="createError" type="error" class="mt-2">{{ createError }}</v-alert>
-            </v-form>
-          </v-card-text>
-        </v-card>
+      <v-col cols="12">
+        <v-btn color="primary" class="modern-btn mb-4" @click="$router.push('/team-management/create-player')">Nuevo Jugador</v-btn>
       </v-col>
-
       <!-- Team Statistics -->
-      <v-col cols="12" md="8">
+      <v-col cols="12">
         <v-card>
           <v-card-title>Estadísticas del Equipo</v-card-title>
           <v-card-text>
@@ -48,9 +31,9 @@
                 <tr>
                   <th>Jugador</th>
                   <th>Partidas</th>
-                  <th>Victorias</th>
-                  <th>Derrotas</th>
-                  <th>Empates</th>
+                  <th>Ganadas</th>
+                  <th>Empatadas</th>
+                  <th>Perdidas</th>
                 </tr>
               </thead>
               <tbody>
@@ -58,8 +41,13 @@
                   <td>{{ stat.player.alias }}</td>
                   <td>{{ stat.games }}</td>
                   <td>{{ stat.wins }}</td>
-                  <td>{{ stat.losses }}</td>
                   <td>{{ stat.draws }}</td>
+                  <td>{{ stat.losses }}</td>
+                  <td>
+                    <v-btn size="small" color="secondary" @click="openDetail(stat.player.id)">
+                      Más información
+                    </v-btn>
+                  </td>
                 </tr>
               </tbody>
             </v-table>
@@ -67,28 +55,31 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-dialog v-model="detailDialog" max-width="900px">
+      <v-card>
+        <v-card-title>Detalles Jugador</v-card-title>
+        <v-card-text>
+          <TeamStats :player-id="selectedPlayerId" v-if="detailDialog" />
+        </v-card-text>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
 <script>
-import { getAllPlayers, createPlayer } from '@/services/playerService'
+import { getAllPlayers } from '@/services/playerService'
 import { getReportsByPlayer } from '@/services/reportService'
+import TeamStats from '@/components/TeamStats.vue'
 
 export default {
+  components: { TeamStats },
   data() {
     return {
       players: [],
       playerStats: [],
       selectedPlayers: [],
-      newPlayer: {
-        nombre: '',
-        apellidos: '',
-        alias: '',
-        email: '',
-        contraseña: ''
-      },
-      creating: false,
-      createError: null
+      detailDialog: false,
+      selectedPlayerId: null
     }
   },
   computed: {
@@ -145,21 +136,9 @@ export default {
       }
       this.playerStats = stats
     },
-    async createPlayerSubmit() {
-      this.createError = null
-      this.creating = true
-      try {
-        const team = this.getUserTeam()
-        const payload = { ...this.newPlayer, equipo: team, team }
-        await createPlayer(payload)
-        this.newPlayer = { nombre: '', apellidos: '', alias: '', email: '', contraseña: '' }
-        await this.fetchPlayers()
-      } catch (err) {
-        console.error('Error creating player', err)
-        this.createError = 'Error creando jugador'
-      } finally {
-        this.creating = false
-      }
+    openDetail(id) {
+      this.selectedPlayerId = id
+      this.detailDialog = true
     }
   }
 }


### PR DESCRIPTION
## Summary
- split player creation to `CreatePlayerView`
- show team overview with per-player statistics and modal graphs
- add reusable `TeamStats` component
- update router and dashboard links

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863de41cc1083218bc2f351551c09bf