### PR TITLE
Add animated background shapes

### DIFF
--- a/frontend/src/components/BackgroundShapes.vue
+++ b/frontend/src/components/BackgroundShapes.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="animated-bg">
+    <svg
+      v-for="(shape, i) in shapes"
+      :key="i"
+      class="shape"
+      :class="shape.type"
+      :style="{
+        left: shape.left + '%',
+        width: shape.size + 'px',
+        height: shape.size + 'px',
+        animationDelay: shape.delay + 's',
+        animationDuration: shape.duration + 's'
+      }"
+      viewBox="0 0 20 20"
+    >
+      <template v-if="shape.type === 'square'">
+        <rect width="20" height="20" />
+      </template>
+      <template v-else-if="shape.type === 'circle'">
+        <circle cx="10" cy="10" r="10" />
+      </template>
+      <template v-else>
+        <polygon points="10,0 20,20 0,20" />
+      </template>
+    </svg>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'BackgroundShapes',
+  data() {
+    return { shapes: [] };
+  },
+  created() {
+    const types = ['square', 'circle', 'triangle'];
+    for (let i = 0; i < 12; i++) {
+      this.shapes.push({
+        type: types[i % 3],
+        left: Math.random() * 100,
+        size: 20 + Math.random() * 20,
+        delay: Math.random() * 5,
+        duration: 15 + Math.random() * 10,
+      });
+    }
+  },
+};
+</script>
+
+<style scoped>
+.animated-bg {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+.shape {
+  position: absolute;
+  bottom: -40px;
+  fill: #6a0dad;
+  opacity: 0.6;
+  animation-name: move-diagonal, color-change;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+@keyframes move-diagonal {
+  from {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  to {
+    transform: translate(120vw, -120vh) rotate(360deg);
+  }
+}
+@keyframes color-change {
+  0% {
+    fill: #6a0dad;
+  }
+  50% {
+    fill: #00bfff;
+  }
+  100% {
+    fill: #6a0dad;
+  }
+}
+</style>

--- a/frontend/src/views/CreateReportView.vue
+++ b/frontend/src/views/CreateReportView.vue
@@ -1,5 +1,7 @@
 <template>
-  <v-container>
+  <div class="report-view">
+    <BackgroundShapes />
+    <v-container>
     <!-- Botón Volver -->
     <v-row class="my-4" justify="center">
       <v-btn
@@ -398,6 +400,7 @@
     </v-dialog>
     <ChatbotModal v-model="chatDialog" />
   </v-container>
+  </div>
 </template>
 
 <script>
@@ -416,9 +419,10 @@ import {
 } from "@/services/reportService";
 import { getAllPlayers } from "@/services/playerService";
 import ChatbotModal from "@/components/ChatbotModal.vue";
+import BackgroundShapes from "@/components/BackgroundShapes.vue";
 
 export default {
-  components: { ChatbotModal },
+  components: { ChatbotModal, BackgroundShapes },
   data() {
     return {
       step: 1,
@@ -928,6 +932,11 @@ export default {
   bottom: 0;
   background-color: var(--v-theme-surface, #121212);
   z-index: 1;
+}
+
+.report-view {
+  position: relative;
+  overflow: hidden;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,5 +1,7 @@
 <template>
-  <v-container fluid>
+  <div class="dashboard-view">
+    <BackgroundShapes />
+    <v-container fluid>
     <!-- Botón Nuevo Reporte -->
     <v-row class="my-4" justify="center">
       <v-btn
@@ -243,12 +245,15 @@
       </v-card>
     </v-dialog>
   </v-container>
+  </div>
 </template>
 
 <script>
 import { getReportsByPlayer } from "@/services/reportService";
+import BackgroundShapes from "@/components/BackgroundShapes.vue";
 
 export default {
+  components: { BackgroundShapes },
   data() {
     return {
       reports: [],
@@ -498,5 +503,10 @@ export default {
     width: 100%;
     margin: 5px auto;
   }
+}
+
+.dashboard-view {
+  position: relative;
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
## Summary
- animate SVG shapes as background effect
- show background shapes on dashboard and create report views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865028d31248321a7547e432e47ac52