### PR TITLE
Add reusable button component and session utils

### DIFF
--- a/frontend/src/components/ModernButton.vue
+++ b/frontend/src/components/ModernButton.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-btn v-bind="$attrs" class="modern-btn" @click="$emit('click', $event)">
+    <slot />
+  </v-btn>
+</template>
+
+<script>
+export default {
+  name: 'ModernButton',
+  inheritAttrs: false,
+};
+</script>
+
+<style scoped>
+.modern-btn {
+  background: linear-gradient(135deg, #00f0ff, #7f00ff);
+  color: white;
+  font-weight: bold;
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.modern-btn:hover {
+  transform: scale(1.02);
+  box-shadow: 0 0 12px #7f00ff;
+}
+@media (max-width: 768px) {
+  .modern-btn {
+    width: 100%;
+    margin: 5px auto;
+  }
+}
+</style>

--- a/frontend/src/utils/session.js
+++ b/frontend/src/utils/session.js
@@ -1,0 +1,10 @@
+export function getSessionUser() {
+  const user = sessionStorage.getItem('user');
+  return user ? JSON.parse(user) : null;
+}
+
+export function getPlayerId() {
+  const u = getSessionUser();
+  if (!u) return null;
+  return u.id ?? u.playerId ?? u.Id ?? u.ID;
+}

--- a/frontend/src/views/CreatePlayerView.vue
+++ b/frontend/src/views/CreatePlayerView.vue
@@ -2,9 +2,9 @@
   <v-container>
     <!-- Return button -->
     <v-row class="my-4" justify="center">
-      <v-btn color="primary" class="modern-btn full-btn" @click="$router.push('/dashboard')">
+      <ModernButton color="primary" class="full-btn" @click="$router.push('/dashboard')">
         Volver al Dashboard
-      </v-btn>
+      </ModernButton>
     </v-row>
     <hr />
 
@@ -20,9 +20,9 @@
               <v-text-field v-model="newPlayer.alias" label="Alias" required />
               <v-text-field v-model="newPlayer.email" label="Correo" required />
               <v-text-field v-model="newPlayer.contraseña" label="Contraseña" type="password" required />
-              <v-btn type="submit" color="primary" class="modern-btn full-btn mt-2" :loading="creating" :disabled="creating">
+              <ModernButton type="submit" color="primary" class="full-btn mt-2" :loading="creating" :disabled="creating">
                 Crear
-              </v-btn>
+              </ModernButton>
               <v-alert v-if="createError" type="error" class="mt-2">{{ createError }}</v-alert>
             </v-form>
           </v-card-text>
@@ -34,8 +34,11 @@
 
 <script>
 import { createPlayer } from '@/services/playerService'
+import { getSessionUser } from '@/utils/session.js'
+import ModernButton from '@/components/ModernButton.vue'
 
 export default {
+  components: { ModernButton },
   data() {
     return {
       newPlayer: {
@@ -51,9 +54,8 @@ export default {
   },
   methods: {
     getUserTeam() {
-      const sessionUser = sessionStorage.getItem('user')
-      if (!sessionUser) return ''
-      const user = JSON.parse(sessionUser)
+      const user = getSessionUser()
+      if (!user) return ''
       return user.equipo || user.team || ''
     },
     async createPlayerSubmit() {
@@ -75,24 +77,4 @@ export default {
 }
 </script>
 
-<style scoped>
-.modern-btn {
-  background: linear-gradient(135deg, #00f0ff, #7f00ff);
-  color: white;
-  font-weight: bold;
-  border-radius: 12px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.modern-btn:hover {
-  transform: scale(1.02);
-  box-shadow: 0 0 12px #7f00ff;
-}
-
-@media (max-width: 768px) {
-  .modern-btn {
-    width: 100%;
-    margin: 5px auto;
-  }
-}
-</style>
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,35 +4,35 @@
     <v-container fluid>
     <!-- Botón Nuevo Reporte -->
     <v-row class="my-4" justify="center">
-      <v-btn
+      <ModernButton
         color="primary"
-        class="modern-btn full-btn mx-2"
+        class="full-btn mx-2"
         @click="$router.push('/create-report')"
       >
         Nuevo Reporte
-      </v-btn>
-      <v-btn
+      </ModernButton>
+      <ModernButton
         color="secondary"
-        class="modern-btn full-btn mx-2"
+        class="full-btn mx-2"
         @click="$router.push('/statistics')"
       >
         Ver Estadísticas
-      </v-btn>
-      <v-btn
+      </ModernButton>
+      <ModernButton
         color="accent"
-        class="modern-btn full-btn mx-2"
+        class="full-btn mx-2"
         @click="$router.push('/profile')"
       >
         Mi Perfil
-      </v-btn>
-      <v-btn
+      </ModernButton>
+      <ModernButton
         v-if="[1, 2, 3].includes(userRole)"
         color="warning"
-        class="modern-btn full-btn mx-2"
+        class="full-btn mx-2"
         @click="$router.push('/team-management/overview')"
       >
         Gestión de Equipo
-      </v-btn>
+      </ModernButton>
     </v-row>
     <hr />
     <!-- Buscador -->
@@ -251,9 +251,10 @@
 <script>
 import { getReportsByPlayer } from "@/services/reportService";
 import BackgroundShapes from "@/components/BackgroundShapes.vue";
+import ModernButton from "@/components/ModernButton.vue";
 
 export default {
-  components: { BackgroundShapes },
+  components: { BackgroundShapes, ModernButton },
   data() {
     return {
       reports: [],
@@ -486,24 +487,6 @@ export default {
   overflow-y: auto;
 }
 
-.modern-btn {
-  background: linear-gradient(135deg, #00f0ff, #7f00ff);
-  color: white;
-  font-weight: bold;
-  border-radius: 12px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.modern-btn:hover {
-  transform: scale(1.02);
-  box-shadow: 0 0 12px #7f00ff;
-}
-
-@media (max-width: 768px) {
-  .modern-btn {
-    width: 100%;
-    margin: 5px auto;
-  }
-}
 
 .dashboard-view {
   position: relative;

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -18,15 +18,15 @@
                 type="password"
                 required
               />
-              <v-btn
+              <ModernButton
                 :loading="loading"
                 :disabled="loading"
                 type="submit"
                 block
-                class="modern-btn full-btn"
+                class="full-btn"
               >
                 Entrar
-              </v-btn>
+              </ModernButton>
             </v-form>
 
             <v-alert v-if="error" type="error" class="mt-4">
@@ -45,8 +45,10 @@
 
 <script>
 import { login } from "@/services/authService";
+import ModernButton from "@/components/ModernButton.vue";
 
 export default {
+  components: { ModernButton },
   data() {
     return {
       email: "",
@@ -151,15 +153,4 @@ export default {
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
-.modern-btn {
-  background: linear-gradient(135deg, #00f0ff, #7f00ff);
-  color: white;
-  font-weight: bold;
-  border-radius: 12px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.modern-btn:hover {
-  transform: scale(1.02);
-  box-shadow: 0 0 12px #7f00ff;
-}
 </style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -2,9 +2,9 @@
   <v-container>
     <!-- Button to return to dashboard -->
     <v-row class="my-4" justify="center">
-      <v-btn color="primary" class="modern-btn full-btn" @click="$router.push('/dashboard')">
+      <ModernButton color="primary" class="full-btn" @click="$router.push('/dashboard')">
         Volver al Dashboard
-      </v-btn>
+      </ModernButton>
     </v-row>
     <hr />
 
@@ -62,15 +62,15 @@
             label="Equipo"
             outlined
           />
-          <v-btn
+          <ModernButton
             type="submit"
             :loading="saving"
             :disabled="saving"
-            class="modern-btn full-btn mt-4"
+            class="full-btn mt-4"
             color="secondary"
           >
             Guardar Cambios
-          </v-btn>
+          </ModernButton>
           <v-alert v-if="saveError" type="error" class="mt-4">
             {{ saveError }}
           </v-alert>
@@ -115,8 +115,11 @@
 import { getPlayerById, updatePlayer } from '@/services/playerService';
 import { getReportsByPlayer, deleteReport } from '@/services/reportService';
 import { getAllTeams } from '@/services/teamService';
+import ModernButton from '@/components/ModernButton.vue';
+import { getPlayerId } from '@/utils/session.js';
 
 export default {
+  components: { ModernButton },
   data() {
     return {
       player: {
@@ -141,7 +144,7 @@ export default {
     };
   },
   created() {
-    const id = this.playerId();
+    const id = getPlayerId();
     if (!id) {
       this.$router.push('/');
       return;
@@ -151,14 +154,8 @@ export default {
     this.fetchTeams();
   },
   methods: {
-    playerId() {
-      const sessionUser = sessionStorage.getItem('user');
-      if (!sessionUser) return null;
-      const user = JSON.parse(sessionUser);
-      return user.id ?? user.playerId ?? user.Id ?? user.ID;
-    },
     async fetchPlayer() {
-      const id = this.playerId();
+      const id = getPlayerId();
       if (!id) return;
       try {
         const { data } = await getPlayerById(id);
@@ -177,7 +174,7 @@ export default {
       }
     },
     async fetchReports() {
-      const id = this.playerId();
+      const id = getPlayerId();
       if (!id) return;
       try {
         const { data } = await getReportsByPlayer(id);
@@ -202,7 +199,7 @@ export default {
       this.saveError = null;
       try {
         const payload = { ...this.player };
-        payload.id = payload.id || this.playerId();
+        payload.id = payload.id || getPlayerId();
         if (payload.foto && payload.foto.startsWith('data:')) {
           payload.foto = payload.foto.split(',')[1];
         }
@@ -249,24 +246,4 @@ export default {
 };
 </script>
 
-<style scoped>
-.modern-btn {
-  background: linear-gradient(135deg, #00f0ff, #7f00ff);
-  color: white;
-  font-weight: bold;
-  border-radius: 12px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.modern-btn:hover {
-  transform: scale(1.02);
-  box-shadow: 0 0 12px #7f00ff;
-}
-
-@media (max-width: 768px) {
-  .modern-btn {
-    width: 100%;
-    margin: 5px auto;
-  }
-}
-</style>
 

--- a/frontend/src/views/TeamOverviewView.vue
+++ b/frontend/src/views/TeamOverviewView.vue
@@ -2,9 +2,9 @@
   <v-container>
     <!-- Return button -->
     <v-row class="my-4" justify="center">
-      <v-btn color="primary" class="modern-btn full-btn" @click="$router.push('/dashboard')">
+      <ModernButton color="primary" class="full-btn" @click="$router.push('/dashboard')">
         Volver al Dashboard
-      </v-btn>
+      </ModernButton>
     </v-row>
     <hr />
 
@@ -15,12 +15,12 @@
           <v-card-text>
             <v-form @submit.prevent="saveTeam">
               <v-text-field v-model="team.nombre" label="Nombre del Equipo" required />
-              <v-btn type="submit" color="primary" class="modern-btn mt-2" :loading="savingTeam">
+              <ModernButton type="submit" color="primary" class="mt-2" :loading="savingTeam">
                 {{ hasTeam ? 'Guardar Cambios' : 'Crear Equipo' }}
-              </v-btn>
-              <v-btn v-if="hasTeam" color="error" class="modern-btn mt-2" @click="deleteTeamDialog = true">
+              </ModernButton>
+              <ModernButton v-if="hasTeam" color="error" class="mt-2" @click="deleteTeamDialog = true">
                 Eliminar Equipo
-              </v-btn>
+              </ModernButton>
             </v-form>
             <v-alert v-if="teamError" type="error" class="mt-2">{{ teamError }}</v-alert>
           </v-card-text>
@@ -42,7 +42,7 @@
 
     <v-row>
       <v-col cols="12">
-        <v-btn color="primary" class="modern-btn mb-4" @click="$router.push('/team-management/create-player')">Nuevo Jugador</v-btn>
+        <ModernButton color="primary" class="mb-4" @click="$router.push('/team-management/create-player')">Nuevo Jugador</ModernButton>
       </v-col>
       <!-- Team Statistics -->
       <v-col cols="12">
@@ -108,9 +108,11 @@ import {
   deleteTeam,
 } from '@/services/teamService'
 import TeamStats from '@/components/TeamStats.vue'
+import ModernButton from '@/components/ModernButton.vue'
+import { getSessionUser } from '@/utils/session.js'
 
 export default {
-  components: { TeamStats },
+  components: { TeamStats, ModernButton },
   data() {
     return {
       players: [],
@@ -142,9 +144,8 @@ export default {
   },
   methods: {
     getUserTeam() {
-      const sessionUser = sessionStorage.getItem('user')
-      if (!sessionUser) return ''
-      const user = JSON.parse(sessionUser)
+      const user = getSessionUser()
+      if (!user) return ''
       return user.equipo || user.team || ''
     },
     async fetchCurrentTeam() {
@@ -209,7 +210,7 @@ export default {
           const { data } = await createTeam({ nombre: this.team.nombre })
           this.team.id = data?.id || data?.teamId || this.team.id
         }
-        const u = JSON.parse(sessionStorage.getItem('user') || '{}')
+        const u = getSessionUser() || {}
         u.equipo = this.team.nombre
         sessionStorage.setItem('user', JSON.stringify(u))
         await this.fetchPlayers()
@@ -227,7 +228,7 @@ export default {
       }
       try {
         await deleteTeam(this.team.id)
-        const u = JSON.parse(sessionStorage.getItem('user') || '{}')
+        const u = getSessionUser() || {}
         u.equipo = ''
         sessionStorage.setItem('user', JSON.stringify(u))
         this.team = { id: null, nombre: '' }
@@ -248,24 +249,4 @@ export default {
 }
 </script>
 
-<style scoped>
-.modern-btn {
-  background: linear-gradient(135deg, #00f0ff, #7f00ff);
-  color: white;
-  font-weight: bold;
-  border-radius: 12px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.modern-btn:hover {
-  transform: scale(1.02);
-  box-shadow: 0 0 12px #7f00ff;
-}
-
-@media (max-width: 768px) {
-  .modern-btn {
-    width: 100%;
-    margin: 5px auto;
-  }
-}
-</style>
 


### PR DESCRIPTION
## Summary
- create `ModernButton` component with shared style
- centralize session helpers in `utils/session.js`
- use `ModernButton` in several views
- refactor views to use session helpers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68650535ffd88321ad26724f7a6ec852