### PR TITLE
Add logout button in Profile view

### DIFF
--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -6,6 +6,11 @@
         Volver al Dashboard
       </ModernButton>
     </v-row>
+    <v-row class="my-4" justify="center">
+      <ModernButton color="error" class="full-btn" @click="logout">
+        Cerrar Sesión
+      </ModernButton>
+    </v-row>
     <hr />
 
     <!-- Profile Edit Card -->
@@ -237,6 +242,10 @@ export default {
         this.deleteDialog = false;
         this.reportToDelete = null;
       }
+    },
+    logout() {
+      sessionStorage.clear();
+      this.$router.push('/');
     },
     formatDate(date) {
       const options = { year: 'numeric', month: '2-digit', day: '2-digit' };


### PR DESCRIPTION
## Summary
- add a **Cerrar Sesión** button to ProfileView
- clear sessionStorage and redirect to `/` when the user logs out

## Testing
- `npm --prefix frontend run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686554e4246c8321a4ffa17bece42f3e