### PR TITLE
Add Cypress e2e test skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ ChatBotPass=your-key-here
 ```
 
 You can set this value in `.env` during development or `.env.production` for a production build. Additional chatbot settings such as the endpoint or model are defined in `frontend/src/config/appsettings.json`.
+
+## End-to-end tests
+
+Cypress is used for e2e testing. To execute the tests you need the
+application running in preview mode on port `4173`:
+
+```bash
+cd frontend
+npm run build
+npm run preview &
+# in another terminal
+npm run test:e2e
+```
+
+This will launch Cypress and run the test suite located in `frontend/cypress`.

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -1,0 +1,9 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4173',
+    specPattern: 'cypress/e2e/**/*.cy.js',
+    supportFile: false,
+  },
+})

--- a/frontend/cypress/e2e/login.cy.js
+++ b/frontend/cypress/e2e/login.cy.js
@@ -1,0 +1,8 @@
+describe('Login page', () => {
+  it('should display the login form', () => {
+    cy.visit('/')
+    cy.contains('Iniciar Sesión')
+    cy.get('input[type=email]').should('exist')
+    cy.get('input[type=password]').should('exist')
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "vite preview"
+    "start": "vite preview",
+    "test:e2e": "cypress run"
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",
@@ -22,6 +23,7 @@
     "@vitejs/plugin-vue": "^5.2.3",
     "sass": "^1.89.1",
     "sass-loader": "^16.0.5",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "cypress": "^13.11.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Cypress as dev dependency
- create basic Cypress config and login test
- document how to run e2e tests with Cypress

## Testing
- `npm --prefix frontend run test:e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865576c1e488321b370c2aafddef942